### PR TITLE
 Remove conda conda-forge::openjdk dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,4 @@ LABEL authors="phil.ewels@scilifelab.se" \
 
 COPY environment.yml /
 RUN conda env create -f /environment.yml && conda clean -a
-ENV PATH /opt/conda/envs/nfcore-methylseq-0.4/bin:$PATH
+ENV PATH /opt/conda/envs/nfcore-methylseq-0.4dev/bin:$PATH

--- a/environment.yml
+++ b/environment.yml
@@ -6,8 +6,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  # Default bismark
-  - conda-forge::openjdk=8.0.144 # Needed for FastQC docker - see bioconda/bioconda-recipes#5026
+  # bismark
   - fastqc=0.11.7
   - trim-galore=0.4.5
   - samtools=1.8

--- a/environment.yml
+++ b/environment.yml
@@ -10,12 +10,12 @@ dependencies:
   - conda-forge::openjdk=8.0.144 # Needed for FastQC docker - see bioconda/bioconda-recipes#5026
   - fastqc=0.11.7
   - trim-galore=0.4.5
-  - samtools=1.7
+  - samtools=1.8
   - bowtie2=2.3.4.1
   - bismark=0.19.0
   - qualimap=2.2.2a
   - multiqc=1.5
   # bwa-meth aligner
-  - picard=2.18.0
+  - picard=2.18.2
   - bwameth=0.2.0
   - methyldackel=0.3.0


### PR DESCRIPTION
The bioconda FastQC recipe has been fixed, so the conda-forge specific dependency is no longer required. See https://github.com/bioconda/bioconda-recipes/pull/8588