### PR TITLE
Add openjdk dep back to conda environment.yml to fix docker build hang

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,6 +7,7 @@ channels:
   - defaults
 dependencies:
   # bismark
+  - conda-forge::openjdk=8.0.144 # Needed for FastQC - conda build hangs without this
   - fastqc=0.11.7
   - trim-galore=0.4.5
   - samtools=1.8

--- a/nextflow.config
+++ b/nextflow.config
@@ -1,6 +1,6 @@
 /*
  * -------------------------------------------------
- *  NGI-ChIPseq Nextflow config file
+ *  nf-core/methylseq Nextflow config file
  * -------------------------------------------------
  * Default config options for all environments.
  * Cluster-specific config options should be saved


### PR DESCRIPTION
The docker image wasn't building properly without this dependency, for whatever reason. Adding it back seems to fix the issue.

Once merged, we can merge into master and I will re-do the v1.0 (or rather, `1.0`) release.