### PR TITLE
Updated Readme singularity badge to use singularity-hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@
 
 [![install with bioconda](https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg)](http://bioconda.github.io/)
 [![Docker Container available](https://img.shields.io/docker/automated/nfcore/methylseq.svg)](https://hub.docker.com/r/nfcore/methylseq/)
-![Singularity Container available](
-https://img.shields.io/badge/singularity-available-7E4C74.svg)
+[![Singularity Container](https://www.singularity-hub.org/static/img/hosted-singularity--hub-%23e32929.svg)](https://singularity-hub.org/collections/1091)
 
 ### Introduction
 


### PR DESCRIPTION
Now that we have a container on Singularity Hub, we should link to it with a readme badge.

This may make the tests fail, so probably need to update the linting script.