### PR TITLE
Prettier logs. Use main nf-core fork for test data.

### DIFF
--- a/conf/test.config
+++ b/conf/test.config
@@ -17,11 +17,11 @@ params {
   // Input data
   singleEnd = true
   readPaths = [
-    ['SRR389222_sub1', ['https://github.com/ewels/nf-core-test-datasets/raw/methylseq/testdata/SRR389222_sub1.fastq.gz']],
-    ['SRR389222_sub2', ['https://github.com/ewels/nf-core-test-datasets/raw/methylseq/testdata/SRR389222_sub2.fastq.gz']],
-    ['SRR389222_sub3', ['https://github.com/ewels/nf-core-test-datasets/raw/methylseq/testdata/SRR389222_sub3.fastq.gz']]
+    ['SRR389222_sub1', ['https://github.com/nf-core/test-datasets/raw/methylseq/testdata/SRR389222_sub1.fastq.gz']],
+    ['SRR389222_sub2', ['https://github.com/nf-core/test-datasets/raw/methylseq/testdata/SRR389222_sub2.fastq.gz']],
+    ['SRR389222_sub3', ['https://github.com/nf-core/test-datasets/raw/methylseq/testdata/SRR389222_sub3.fastq.gz']]
   ]
   // Genome references
-  fasta = 'https://github.com/ewels/nf-core-test-datasets/raw/methylseq/reference/genome.fa'
-  fasta_index = 'https://github.com/ewels/nf-core-test-datasets/raw/methylseq/reference/genome.fa.fai'
+  fasta = 'https://github.com/nf-core/test-datasets/raw/methylseq/reference/genome.fa'
+  fasta_index = 'https://github.com/nf-core/test-datasets/raw/methylseq/reference/genome.fa.fai'
 }

--- a/main.nf
+++ b/main.nf
@@ -159,10 +159,18 @@ if(params.readPaths){
         .into { read_files_fastqc; read_files_trimming }
 }
 
-log.info "=================================================="
-log.info " nf-core/methylseq : Bisulfite-Seq Best Practice v${params.version}"
-log.info "=================================================="
+log.info """=======================================================
+                                          ,--./,-.
+          ___     __   __   __   ___     /,-._.--~\'
+    |\\ | |__  __ /  ` /  \\ |__) |__         }  {
+    | \\| |       \\__, \\__/ |  \\ |___     \\`-._,-`-,
+                                          `._,._,\'
+
+nf-core/methylseq : Bisulfite-Seq Best Practice v${params.version}
+======================================================="""
 def summary = [:]
+summary['Pipeline Name']  = 'nf-core/methylseq'
+summary['Pipeline Version'] = params.version
 summary['Run Name']       = custom_runName ?: workflow.runName
 summary['Reads']          = params.reads
 summary['Aligner']        = params.aligner
@@ -198,8 +206,8 @@ summary['Max CPUs']       = params.max_cpus
 summary['Max Time']       = params.max_time
 summary['Output dir']     = params.outdir
 summary['Working dir']    = workflow.workDir
-summary['Container']      = workflow.container
-if(workflow.revision) summary['Pipeline Release'] = workflow.revision
+summary['Container Engine'] = workflow.containerEngine
+if(workflow.containerEngine) summary['Container'] = workflow.container
 summary['Current home']   = "$HOME"
 summary['Current user']   = "$USER"
 summary['Current path']   = "$PWD"


### PR DESCRIPTION
Now with prettier log headers:

```
$ nextflow run ../methylseq/ -profile test,docker

N E X T F L O W  ~  version 0.30.0
Launching `../methylseq/main.nf` [nauseous_chandrasekhar] - revision: f7f3b27b3c
=======================================================
                                          ,--./,-.
          ___     __   __   __   ___     /,-._.--~'
    |\ | |__  __ /  ` /  \ |__) |__         }  {
    | \| |       \__, \__/ |  \ |___     \`-._,-`-,
                                          `._,._,'

nf-core/methylseq : Bisulfite-Seq Best Practice v1.1dev
=======================================================
Pipeline Name     : nf-core/methylseq
Pipeline Version  : 1.1dev
Run Name          : nauseous_chandrasekhar
Reads             : data/*_R{1,2}.fastq.gz
Aligner           : bismark
Data Type         : Single-End
Genome            : false
Fasta Ref         : https://github.com/ewels/nf-core-test-datasets/raw/methylseq/reference/genome.fa
Trim R1           : 0
Trim R2           : 0
Trim 3' R1        : 0
Trim 3' R2        : 0
Deduplication     : Yes
Directional Mode  : Yes
All C Contexts    : No
Save Reference    : No
Save Trimmed      : No
Save Unmapped     : No
Save Intermeds    : No
Max Memory        : 6 GB
Max CPUs          : 2
Max Time          : 2d
Output dir        : ./results
Working dir       : /Users/philewels/GitHub/nf-core/testing/work
Software deps     : docker
Container Engine  : docker
Container         : nfcore/methylseq:latest
Current home      : /Users/philewels
Current user      : philewels
Current path      : /Users/philewels/GitHub/nf-core/testing
Script dir        : /Users/philewels/GitHub/nf-core/methylseq
Config Profile    : test,docker
=========================================
```