### PR TITLE
add runOptions to Docker profile to fix ownership on files

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -47,7 +47,10 @@ profiles {
     includeConfig 'conf/igenomes.config'
   }
   conda { process.conda = "$baseDir/environment.yml" }
-  docker { docker.enabled = true }
+  docker {
+    docker.enabled = true
+    docker.runOptions = '-u $(id -u):$(id -g)'
+    }
   singularity { singularity.enabled = true }
   uppmax {
     includeConfig 'conf/base.config'


### PR DESCRIPTION
Add runOptions to Docker profile to fix ownership on files.
Otherwise we have `Permission denied` when deleting the work directory.