### PR TITLE
Move warning messages below initial log. Stop ignoring failures.

### DIFF
--- a/conf/base.config
+++ b/conf/base.config
@@ -27,9 +27,6 @@ process {
     memory = { check_max( 64.GB * task.attempt, 'memory') }
     time = { check_max( 36.h * task.attempt, 'time') }
   }
-  $fastqc {
-    errorStrategy = { task.exitStatus in [143,137] ? 'retry' : 'ignore' }
-  }
   $trim_galore {
     cpus = { check_max( 2 * task.attempt, 'cpus') }
     memory = { check_max( 16.GB * task.attempt, 'memory') }
@@ -50,26 +47,14 @@ process {
     memory = { check_max( 32.GB * task.attempt, 'memory') }
     time = { check_max( 1.d * task.attempt, 'time') }
   }
-  $bismark_report {
-    errorStrategy = { task.exitStatus in [143,137] ? 'retry' : 'ignore' }
-  }
-  $bismark_summary {
-    errorStrategy = { task.exitStatus in [143,137] ? 'retry' : 'ignore' }
-  }
   $qualimap {
     cpus = { check_max( 4 * task.attempt, 'cpus') }
     memory = { check_max( 32.GB * task.attempt, 'memory') }
     time = { check_max( 6.h * task.attempt, 'time') }
-    errorStrategy = { task.exitStatus in [143,137] ? 'retry' : 'ignore' }
   }
   $get_software_versions {
     validExitStatus = [0,1]
-    executor = 'local'
     errorStrategy = 'ignore'
-  }
-  $multiqc {
-    executor = 'local'
-    errorStrategy = { task.exitStatus in [143,137] ? 'retry' : 'ignore' }
   }
 
   $bwamem_align {

--- a/main.nf
+++ b/main.nf
@@ -26,32 +26,6 @@ params.bwa_meth_index = params.genome ? params.genomes[ params.genome ].bwa_meth
 params.fasta = params.genome ? params.genomes[ params.genome ].fasta ?: false : false
 params.fasta_index = params.genome ? params.genomes[ params.genome ].fasta_index ?: false : false
 
-// Check that Nextflow version is up to date enough
-// try / throw / catch works for NF versions < 0.25 when this was implemented
-try {
-  if( ! nextflow.version.matches(">= $params.nf_required_version") ){
-    throw GroovyException('Nextflow version too old')
-  }
-} catch (all) {
-  log.error "====================================================\n" +
-            "  Nextflow version $params.nf_required_version required! You are running v$workflow.nextflow.version.\n" +
-            "  Pipeline execution will continue, but things may break.\n" +
-            "  Please run `nextflow self-update` to update Nextflow.\n" +
-            "============================================================"
-}
-// Show a big error message if we're running on the base config and an uppmax cluster
-if( workflow.profile == 'standard'){
-    if ( "hostname".execute().text.contains('.uppmax.uu.se') ) {
-        log.error "====================================================\n" +
-                  "  WARNING! You are running with the default 'standard'\n" +
-                  "  pipeline config profile, which runs on the head node\n" +
-                  "  and assumes all software is on the PATH.\n" +
-                  "  ALL JOBS ARE RUNNING LOCALLY and stuff will probably break.\n" +
-                  "  Please use `-profile uppmax` to run on UPPMAX clusters.\n" +
-                  "============================================================"
-    }
-}
-
 // Validate inputs
 if (params.aligner != 'bismark' && params.aligner != 'bwameth'){
     exit 1, "Invalid aligner option: ${params.aligner}. Valid options: 'bismark', 'bwameth'"
@@ -220,6 +194,31 @@ if(params.email) summary['E-mail Address'] = params.email
 log.info summary.collect { k,v -> "${k.padRight(18)}: $v" }.join("\n")
 log.info "========================================="
 
+// Check that Nextflow version is up to date enough
+// try / throw / catch works for NF versions < 0.25 when this was implemented
+try {
+  if( ! nextflow.version.matches(">= $params.nf_required_version") ){
+    throw GroovyException('Nextflow version too old')
+  }
+} catch (all) {
+  log.error "====================================================\n" +
+            "  Nextflow version $params.nf_required_version required! You are running v$workflow.nextflow.version.\n" +
+            "  Pipeline execution will continue, but things may break.\n" +
+            "  Please run `nextflow self-update` to update Nextflow.\n" +
+            "============================================================"
+}
+// Show a big error message if we're running on the base config and an uppmax cluster
+if( workflow.profile == 'standard'){
+    if ( "hostname".execute().text.contains('.uppmax.uu.se') ) {
+        log.error "====================================================\n" +
+                  "  WARNING! You are running with the default 'standard'\n" +
+                  "  pipeline config profile, which runs on the head node\n" +
+                  "  and assumes all software is on the PATH.\n" +
+                  "  ALL JOBS ARE RUNNING LOCALLY and stuff will probably break.\n" +
+                  "  Please use `-profile uppmax` to run on UPPMAX clusters.\n" +
+                  "============================================================"
+    }
+}
 
 /*
  * PREPROCESSING - Build Bismark index


### PR DESCRIPTION
Also stopped running a couple of processes with the `local` executor, as this breaks stuff for people running on kubernetes...