### PR TITLE
Remove local executor usage

### DIFF
--- a/conf/base.config
+++ b/conf/base.config
@@ -64,11 +64,9 @@ process {
   }
   $get_software_versions {
     validExitStatus = [0,1]
-    executor = 'local'
     errorStrategy = 'ignore'
   }
   $multiqc {
-    executor = 'local'
     errorStrategy = { task.exitStatus in [143,137] ? 'retry' : 'ignore' }
   }
 


### PR DESCRIPTION
The local executor prevents the execution is container native environment 
such K8s and AWS Batch.  Moreover some infra does not allow the local
 execution of containers.