### PR TITLE
Safer PBAT trimming, memory for Picard

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,9 @@ install:
   - cd ${TRAVIS_BUILD_DIR}/tests
 
 env:
-  - ALIGNER=bismark NXF_VER=0.31.0
+  - ALIGNER=bismark NXF_VER='0.32.0'
   - ALIGNER=bismark
-  - ALIGNER=bwameth NXF_VER=0.31.0
+  - ALIGNER=bwameth NXF_VER='0.32.0'
   - ALIGNER=bwameth
 
 script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.2dev
 
 * Fixed bug in MultiQC process that skipped results from some tools
+* Trim 9bp from both ends of both reads for PBAT mode.
 
 ## [v1.1](https://github.com/nf-core/methylseq/releases/tag/1.1) - 2018-08-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,16 @@
 
 ## 1.2dev
 
-* Fixed bug in MultiQC process that skipped results from some tools
+#### New features
 * Trim 9bp from both ends of both reads for PBAT mode.
+
+#### Software updates
+
+#### Bug fixes
+* Fixed bug in MultiQC process that skipped results from some tools
+* Supply available memory as argument to Picard MarkDuplicates
+
+
 
 ## [v1.1](https://github.com/nf-core/methylseq/releases/tag/1.1) - 2018-08-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 * Trim 9bp from both ends of both reads for PBAT mode.
 
 #### Software updates
+* Fastqc `0.11.7` > `0.11.8`
+* Bowtie2 `2.3.4.2` > `2.3.4.3`
+* Bismark `0.19.1` > `0.20.0`
+* Qualimap `2.2.2a` > `2.2.2b`
+* Picard `2.18.11` > `2.18.14`
 
 #### Bug fixes
 * Fixed bug in MultiQC process that skipped results from some tools

--- a/LICENCE.md
+++ b/LICENCE.md
@@ -1,5 +1,7 @@
 The MIT License (MIT)
 
+Copyright (c) Phil Ewels
+
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights
@@ -17,4 +19,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ![nf-core/methylseq](docs/images/methylseq_logo.png)
 
 [![Build Status](https://travis-ci.org/nf-core/methylseq.svg?branch=master)](https://travis-ci.org/nf-core/methylseq)
-[![Nextflow](https://img.shields.io/badge/nextflow-%E2%89%A50.31.0-brightgreen.svg)](https://www.nextflow.io/)
+[![Nextflow](https://img.shields.io/badge/nextflow-%E2%89%A50.32.0-brightgreen.svg)](https://www.nextflow.io/)
 [![DOI](https://zenodo.org/badge/124913037.svg)](https://zenodo.org/badge/latestdoi/124913037)
 [![Gitter](https://img.shields.io/badge/gitter-%20join%20chat%20%E2%86%92-4fb99a.svg)](https://gitter.im/nf-core/Lobby)
 

--- a/environment.yml
+++ b/environment.yml
@@ -8,14 +8,14 @@ channels:
 dependencies:
   # bismark
   - conda-forge::openjdk=8.0.144 # Needed for FastQC - conda build hangs without this
-  - fastqc=0.11.7
+  - fastqc=0.11.8
   - trim-galore=0.5.0
   - samtools=1.9
-  - bowtie2=2.3.4.2
-  - bismark=0.19.1
-  - qualimap=2.2.2a
+  - bowtie2=2.3.4.3
+  - bismark=0.20.0
+  - qualimap=2.2.2b
   - multiqc=1.6
   # bwa-meth aligner
-  - picard=2.18.11
+  - picard=2.18.14
   - bwameth=0.2.2
   - methyldackel=0.3.0

--- a/main.nf
+++ b/main.nf
@@ -77,9 +77,9 @@ params.accel = false
 params.zymo = false
 params.cegx = false
 if(params.pbat){
-    params.clip_r1 = 6
+    params.clip_r1 = 9
     params.clip_r2 = 9
-    params.three_prime_clip_r1 = 6
+    params.three_prime_clip_r1 = 9
     params.three_prime_clip_r2 = 9
 } else if(params.single_cell){
     params.clip_r1 = 6

--- a/main.nf
+++ b/main.nf
@@ -665,8 +665,14 @@ if(params.aligner == 'bwameth'){
             file "${bam.baseName}.markDups_metrics.txt" into picard_results
 
             script:
+            if( !task.memory ){
+                log.info "[Picard MarkDuplicates] Available memory not known - defaulting to 3GB. Specify process memory requirements to change this."
+                avail_mem = 3
+            } else {
+                avail_mem = task.memory.toGiga()
+            }
             """
-            picard MarkDuplicates \\
+            picard -Xmx${avail_mem}g MarkDuplicates \\
                 INPUT=$bam \\
                 OUTPUT=${bam.baseName}.markDups.bam \\
                 METRICS_FILE=${bam.baseName}.markDups_metrics.txt \\

--- a/main.nf
+++ b/main.nf
@@ -140,11 +140,11 @@ log.info """=======================================================
     | \\| |       \\__, \\__/ |  \\ |___     \\`-._,-`-,
                                           `._,._,\'
 
-nf-core/methylseq : Bisulfite-Seq Best Practice v${params.version}
+nf-core/methylseq : Bisulfite-Seq Best Practice v${workflow.manifest.version}
 ======================================================="""
 def summary = [:]
 summary['Pipeline Name']  = 'nf-core/methylseq'
-summary['Pipeline Version'] = params.version
+summary['Pipeline Version'] = workflow.manifest.version
 summary['Run Name']       = custom_runName ?: workflow.runName
 summary['Reads']          = params.reads
 summary['Aligner']        = params.aligner
@@ -194,19 +194,6 @@ if(params.email) summary['E-mail Address'] = params.email
 log.info summary.collect { k,v -> "${k.padRight(18)}: $v" }.join("\n")
 log.info "========================================="
 
-// Check that Nextflow version is up to date enough
-// try / throw / catch works for NF versions < 0.25 when this was implemented
-try {
-  if( ! nextflow.version.matches(">= $params.nf_required_version") ){
-    throw GroovyException('Nextflow version too old')
-  }
-} catch (all) {
-  log.error "====================================================\n" +
-            "  Nextflow version $params.nf_required_version required! You are running v$workflow.nextflow.version.\n" +
-            "  Pipeline execution will continue, but things may break.\n" +
-            "  Please run `nextflow self-update` to update Nextflow.\n" +
-            "============================================================"
-}
 // Show a big error message if we're running on the base config and an uppmax cluster
 if( workflow.profile == 'standard'){
     if ( "hostname".execute().text.contains('.uppmax.uu.se') ) {
@@ -757,7 +744,7 @@ process get_software_versions {
 
     script:
     """
-    echo "$params.version" &> v_ngi_methylseq.txt
+    echo "$workflow.manifest.version" &> v_ngi_methylseq.txt
     echo "$workflow.nextflow.version" &> v_nextflow.txt
     bismark_genome_preparation --version &> v_bismark_genome_preparation.txt
     fastqc --version &> v_fastqc.txt
@@ -828,7 +815,7 @@ workflow.onComplete {
       subject = "[nf-core/methylseq] FAILED: $workflow.runName"
     }
     def email_fields = [:]
-    email_fields['version'] = params.version
+    email_fields['version'] = workflow.manifest.version
     email_fields['runName'] = workflow.runName
     email_fields['success'] = workflow.success
     email_fields['dateComplete'] = workflow.complete

--- a/nextflow.config
+++ b/nextflow.config
@@ -96,9 +96,10 @@ dag {
 
 manifest {
   name = 'nf-core/methylseq'
+  author = 'Phil Ewels'
   description = 'Methylation (Bisulfite-Sequencing) Best Practice analysis pipeline, part of the nf-core community.'
-  pipelineVersion = '1.2dev'
-  nextflowVersion = '>=0.31.0'
+  version = '1.2dev'
+  nextflowVersion = '>=0.32.0'
   homePage = 'https://github.com/nf-core/methylseq'
   mainScript = 'main.nf'
 }


### PR DESCRIPTION
* Trim 9bp from both reads both ends for PBAT data
    * Sometimes a 6N adapter is used, sometimes a 9N. Better to default to the longer adapter type in case.
* Supply memory to Picard MarkDups. See nf-core/methylseq#45