### PR TITLE
Update --meth_cutoff default to 5 reads, and docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # nf-core/methylseq
 
+## 2018-11-27
+* Add meth_cutoff = 5 default. Now, 5 reads (previously 1) are required to call methylation via bismark_methylation_extractor. 
+
 ## [v1.1](https://github.com/nf-core/methylseq/releases/tag/1.1) - 2018-08-09
 
 * Tests simplified - now work by simply using the `test` config profile

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -30,6 +30,7 @@
     * [`--saveTrimmed`](#--savetrimmed)
     * [`--saveAlignedIntermediates`](#--savealignedintermediates)
     * [`--mindepth`](#--mindepth)
+    * [`--meth_cutoff`](#--meth_cutoff)
     * [`--ignoreFlags`](#--ignoreflags)
 * [Job Resources](#job-resources)
     * [Automatic resubmission](#automatic-resubmission)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -248,6 +248,9 @@ By default intermediate BAM files will not be saved. The final BAM files created
 ### `--mindepth`
 Specify to specify a minimum read coverage for MethylDackel to report a methylation call.
 
+### `--meth_cutoff`
+Specify to specify a minimum read coverage for Bismark's bismark_methylation_extractor to report a methylation call.
+
 ### `--ignoreFlags`
 Specify to run MethylDackel with the `--ignoreFlags` flag to ignore SAM flags.
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -37,6 +37,7 @@ params {
   // So -60 would allow 10 mismatches or ~ 8 x 1-2bp indels
   // Bismark default is 0.2 (L,0,-0.2), Bowtie2 default is 0.6 (L,0,-0.6)
   mindepth = 0
+  meth_cutoff = 5
   ignoreFlags = false
 }
 


### PR DESCRIPTION
Hi Phil, good idea, looks better now.

See https://github.com/nf-core/methylseq/pull/49

Hope that hits the spot.

Colin