### PR TITLE
add where_are_my_files.txt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Picard `2.18.11` > `2.18.14`
 
 #### Bug fixes
+* Fixed error when running the pipeline with --unmapped
 * Fixed error where single-sample reports could mix up log files [#48](https://github.com/nf-core/methylseq/issues/48)
 * Fixed bug in MultiQC process that skipped results from some tools
 * Supply available memory as argument to Picard MarkDuplicates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 #### New features
 * Trim 9bp from both ends of both reads for PBAT mode.
+* Save `where_are_my_files.txt` to results directory to inform the user about missing intermediate files [#42](https://github.com/nf-core/methylseq/issues/42)
 
 #### Software updates
 * Fastqc `0.11.7` > `0.11.8`

--- a/assets/where_are_my_files.txt
+++ b/assets/where_are_my_files.txt
@@ -1,0 +1,44 @@
+=====================
+ Where are my files?
+=====================
+
+By default, the nf-core/methylseq pipeline does not save large intermediate files to the
+results directory. This is to try to conserve disk space.
+
+These files can be found in the pipeline `work` directory if needed.
+Alternatively, re-run the pipeline using `-resume` in addition to one of
+the below command-line options and they will be copied into the results directory:
+
+`--unmapped` (bismark only)
+Specify to save FastQ files containing reads that didn't map to the reference genome to the results directory.
+
+`--saveAlignedIntermediates`
+The final BAM files created after the Bismark deduplicate / Picard MarkDuplicates steps are always saved
+and can be found in the `bismark_deduplicated/` or `bwa-mem_markDuplicates/` folder, respectively.
+Specify this flag to also copy out BAM files from bismark / bwameth alignment and sorting steps.
+
+`--saveTrimmed`
+Specify to save trimmed FastQ files to the results directory.
+
+`--saveReference`
+Save any downloaded or generated reference genome files to your results folder.
+These can then be used for future pipeline runs, reducing processing times.
+
+
+-----------------------------------
+ Setting defaults in a config file
+-----------------------------------
+If you would always like these files to be saved without having to specify this on
+the command line, you can save the following to your personal configuration file
+(eg. `~/.nextflow/config`):
+
+params.saveReference = true
+params.saveTrimmed = true
+params.saveAlignedIntermediates = true
+params.unmapped = true
+
+For more help, see the following documentation:
+
+https://github.com/nf-core/methylseq/blob/master/docs/usage.md
+https://www.nextflow.io/docs/latest/getstarted.html
+https://www.nextflow.io/docs/latest/config.html

--- a/main.nf
+++ b/main.nf
@@ -365,7 +365,7 @@ if(params.aligner == 'bismark'){
         output:
         set val(name), file("*.bam") into bam, bam_2
         set val(name), file("*report.txt") into bismark_align_log_1, bismark_align_log_2, bismark_align_log_3
-        if(params.unmapped){ file "*.fq.gz" into bismark_unmapped }
+        file "*.fq.gz" optional true into bismark_unmapped
         file "where_are_my_files.txt"
 
         script:


### PR DESCRIPTION
Adresses #42

This implements the same feature present in nf-core/rnaseq , informing users about missing intermediate files. 

I also found a bug when running the pipeline with the `--unmapped` flag:
```
ERROR ~ No such variable: bismark_unmapped
```

This could be fixed by exchanging the if condition in the output declaration with nextflow's [`optional true`](https://www.nextflow.io/docs/latest/process.html#optional-output) attribute