### PR TITLE
Update travis config to actually use generated alignment index

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,14 @@
 sudo: required
 language: python
 jdk: openjdk8
-services:
-  - docker
-python:
-  - "3.6"
+services: docker
+python: '3.6'
 cache: pip
 matrix:
   fast_finish: true
 
 before_install:
-  # PRs made to 'master' branch should always orginate from another repo or the 'dev' branch
+  # PRs to master are only ok if coming from dev branch
   - '[ $TRAVIS_PULL_REQUEST = "false" ] || [ $TRAVIS_BRANCH != "master" ] || ([ $TRAVIS_PULL_REQUEST_SLUG = $TRAVIS_REPO_SLUG ] && [ $TRAVIS_PULL_REQUEST_BRANCH = "dev" ])'
   # Pull the docker image first so the test doesn't wait for this
   - docker pull nfcore/methylseq
@@ -19,21 +17,20 @@ before_install:
 
 install:
   # Install Nextflow
-  - mkdir /tmp/nextflow
-  - cd /tmp/nextflow
+  - mkdir /tmp/nextflow && cd /tmp/nextflow
   - wget -qO- get.nextflow.io | bash
   - sudo ln -s /tmp/nextflow/nextflow /usr/local/bin/nextflow
   # Install nf-core/tools
+  - pip install --upgrade pip
   - pip install nf-core
   # Reset
-  - mkdir ${TRAVIS_BUILD_DIR}/tests
-  - cd ${TRAVIS_BUILD_DIR}/tests
+  - mkdir ${TRAVIS_BUILD_DIR}/tests && cd ${TRAVIS_BUILD_DIR}/tests
 
 env:
-  - ALIGNER=bismark NXF_VER='0.32.0'
-  - ALIGNER=bismark
-  - ALIGNER=bwameth NXF_VER='0.32.0'
-  - ALIGNER=bwameth
+  - ALIGNER=bismark ALIGNER_REF="--bismark_index ${TRAVIS_BUILD_DIR}/tests/results/reference_genome/BismarkIndex/" NXF_VER='0.32.0'
+  - ALIGNER=bismark ALIGNER_REF="--bismark_index ${TRAVIS_BUILD_DIR}/tests/results/reference_genome/BismarkIndex/"
+  - ALIGNER=bwameth ALIGNER_REF="--bwa_meth_index ${TRAVIS_BUILD_DIR}/tests/results/reference_genome/genome.fa" NXF_VER='0.32.0'
+  - ALIGNER=bwameth ALIGNER_REF="--bwa_meth_index ${TRAVIS_BUILD_DIR}/tests/results/reference_genome/genome.fa"
 
 script:
   # Lint the pipeline code
@@ -41,6 +38,6 @@ script:
   # Run, build reference genome
   - nextflow run ${TRAVIS_BUILD_DIR} -profile test,docker --aligner $ALIGNER --saveReference
   # Basic run with supplied reference
-  - nextflow run ${TRAVIS_BUILD_DIR} -profile test,docker --aligner $ALIGNER ${TRAVIS_BUILD_DIR}/tests/results/reference_genome/BismarkIndex/
+  - nextflow run ${TRAVIS_BUILD_DIR} -profile test,docker --aligner $ALIGNER $ALIGNER_REF
   # Run, RRBS mode with no trimming
   - nextflow run ${TRAVIS_BUILD_DIR} -profile test,docker --aligner $ALIGNER --notrim --rrbs

--- a/main.nf
+++ b/main.nf
@@ -160,7 +160,8 @@ summary['Data Type']      = params.singleEnd ? 'Single-End' : 'Paired-End'
 summary['Genome']         = params.genome
 if(params.bismark_index) summary['Bismark Index'] = params.bismark_index
 if(params.bwa_meth_index) summary['BWA-Meth Index'] = "${params.bwa_meth_index}*"
-else if(params.fasta)    summary['Fasta Ref'] = params.fasta
+if(params.fasta)        summary['Fasta Ref'] = params.fasta
+if(params.fasta_index)  summary['Fasta Index'] = params.fasta_index
 if(params.rrbs) summary['RRBS Mode'] = 'On'
 if(params.relaxMismatches) summary['Mismatch Func'] = "L,0,-${params.numMismatches} (Bismark default = L,0,-0.2)"
 if(params.notrim)       summary['Trimming Step'] = 'Skipped'

--- a/main.nf
+++ b/main.nf
@@ -49,12 +49,12 @@ if ( params.fasta ){
         .fromPath(params.fasta, checkIfExists: true)
         .into { fasta_1; fasta_2; fasta_3 }
 }
+else if( params.aligner == 'bwameth') {
+    exit 1, "No Fasta reference specified! This is required by MethylDackel."
+}
 if( params.fasta_index ){
     fasta_index = Channel
         .fromPath(params.fasta_index, checkIfExists: true)
-}
-if( params.aligner == 'bwameth' && (!params.fasta_index || !params.fasta )) {
-    exit 1, "Fasta & Fasta index references missing! These are required by MethylDackel."
 }
 
 multiqc_config = Channel

--- a/main.nf
+++ b/main.nf
@@ -40,10 +40,6 @@ else if( params.bwa_meth_index && params.aligner == 'bwameth' ){
         .fromPath("${params.bwa_meth_index}*", checkIfExists: true)
         .ifEmpty { exit 1, "bwa-meth index not found: ${params.bwa_meth_index}" }
 }
-else if( params.fasta_index && params.aligner == 'bwameth' ){
-    fasta_index = Channel
-        .fromPath(params.fasta_index, checkIfExists: true)
-}
 else if( !params.fasta ) {
     exit 1, "No reference genome index specified!"
 }
@@ -53,8 +49,12 @@ if ( params.fasta ){
         .fromPath(params.fasta, checkIfExists: true)
         .into { fasta_1; fasta_2; fasta_3 }
 }
-else if( params.aligner == 'bwameth') {
-    exit 1, "No Fasta reference specified! This is required by MethylDackel."
+if( params.fasta_index ){
+    fasta_index = Channel
+        .fromPath(params.fasta_index, checkIfExists: true)
+}
+if( params.aligner == 'bwameth' && (!params.fasta_index || !params.fasta )) {
+    exit 1, "Fasta & Fasta index references missing! These are required by MethylDackel."
 }
 
 multiqc_config = Channel


### PR DESCRIPTION
The current `.travis.yml` config doesn't actually test the given alignment index as expected:
https://github.com/nf-core/methylseq/blob/b517262de1eb65caa8e8ba9f74070cbe4e1255a3/.travis.yml#L44

(no `--bismark_index` flag or bwameth support).

This PR makes that test function as intended, and also updates the travis config to match the latest nf-core template design (including upgrade of pip).