### PR TITLE
Version bump for 1.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
   # Pull the docker image first so the test doesn't wait for this
   - docker pull nfcore/methylseq:dev
   # Fake the tag locally so that the pipeline runs properly
-  - docker tag nfcore/methylseq:dev nfcore/methylseq:latest
+  - docker tag nfcore/methylseq:dev nfcore/methylseq:1.2
 
 install:
   # Install Nextflow

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # nf-core/methylseq
 
-## 1.2dev
+## [v1.2](https://github.com/nf-core/methylseq/releases/tag/1.2) - 2018-12-26
 
 #### New features
 * Trim 9bp from both ends of both reads for PBAT mode.

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,4 @@ LABEL authors="phil.ewels@scilifelab.se" \
 
 COPY environment.yml /
 RUN conda env create -f /environment.yml && conda clean -a
-ENV PATH /opt/conda/envs/nf-core-methylseq-1.2dev/bin:$PATH
+ENV PATH /opt/conda/envs/nf-core-methylseq-1.2/bin:$PATH

--- a/Singularity
+++ b/Singularity
@@ -4,10 +4,10 @@ Bootstrap:docker
 %labels
     MAINTAINER Phil Ewels <phil.ewels@scilifelab.se>
     DESCRIPTION Container image containing all requirements for the nf-core/methylseq pipeline
-    VERSION 1.2dev
+    VERSION 1.2
 
 %environment
-    PATH=/opt/conda/envs/nf-core-methylseq-1.2dev/bin:$PATH
+    PATH=/opt/conda/envs/nf-core-methylseq-1.2/bin:$PATH
     export PATH
 
 %files

--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,6 @@
 # You can use this file to create a conda environment for this pipeline:
 #   conda env create -f environment.yml
-name: nf-core-methylseq-1.2dev
+name: nf-core-methylseq-1.2
 channels:
   - bioconda
   - conda-forge

--- a/nextflow.config
+++ b/nextflow.config
@@ -12,7 +12,7 @@
 // Configurable variables
 params {
 
-  container = 'nfcore/methylseq:latest' // Container slug. Stable releases should specify release tag!!
+  container = 'nfcore/methylseq:1.2' // Container slug. Stable releases should specify release tag!!
 
   // Pipeline options
   aligner = 'bismark'
@@ -98,7 +98,7 @@ manifest {
   name = 'nf-core/methylseq'
   author = 'Phil Ewels'
   description = 'Methylation (Bisulfite-Sequencing) Best Practice analysis pipeline, part of the nf-core community.'
-  version = '1.2dev'
+  version = '1.2'
   nextflowVersion = '>=0.32.0'
   homePage = 'https://github.com/nf-core/methylseq'
   mainScript = 'main.nf'


### PR DESCRIPTION
Bumping the version for a v1.2 release.

Note that this should also test the changes to the docker container built in #57