### PR TITLE
Add GRCh38

### DIFF
--- a/conf/igenomes.config
+++ b/conf/igenomes.config
@@ -10,6 +10,10 @@
 params {
   // illumina iGenomes reference file paths on UPPMAX
   genomes {
+    'GRCh38' {
+      bismark = "${params.igenomes_base}/Homo_sapiens/NCBI/GRCh38/Sequence/BismarkIndex"
+      fasta   = "${params.igenomes_base}/Homo_sapiens/NCBI/GRCh38/Sequence/WholeGenomeFasta"
+    }
     'GRCh37' {
       bismark = "${params.igenomes_base}/Homo_sapiens/Ensembl/GRCh37/Sequence/BismarkIndex"
       fasta   = "${params.igenomes_base}/Homo_sapiens/Ensembl/GRCh37/Sequence/WholeGenomeFasta"


### PR DESCRIPTION
Adding GRCh38 as a reference genome option, even though it is the NCBI version and not the ensembl version.