### PR TITLE
Fix bug that made pipeline work on only one sample. 

### DIFF
--- a/conf/base.config
+++ b/conf/base.config
@@ -54,7 +54,6 @@ process {
   }
   withName:get_software_versions {
     validExitStatus = [0,1]
-    errorStrategy = 'ignore'
   }
 
   withName:bwamem_align {

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ channels:
 dependencies:
   # Dependencies for FastQC
   - conda-forge::openjdk=8.0.144
-  - font-ttf-dejavu-sans-mono=2.37
+  - anaconda::font-ttf-dejavu-sans-mono=2.37
   - fontconfig=2.12.6
   - fastqc=0.11.8
   # Default bismark pipeline

--- a/main.nf
+++ b/main.nf
@@ -808,7 +808,7 @@ process get_software_versions {
     bwameth.py --version &> v_bwameth.txt
     picard MarkDuplicates --version &> v_picard_markdups.txt 2>&1 || true
     MethylDackel --version &> v_methyldackel.txt
-    qualimap --version &> v_qualimap.txt
+    qualimap --version &> v_qualimap.txt || true
     multiqc --version &> v_multiqc.txt
     scrape_software_versions.py &> software_versions_mqc.yaml
     """


### PR DESCRIPTION
When we refactored the input channels in the last release, we missed that the `wherearemyfiles` channels aren't collected. This means that they are consumed after the first file, meaning that the pipeline can only process one sample at a time. This fixes #66

This PR fixes that problem by using `.collect()` on those channels.

Also, in a small tweak, I updated the MultiQC process to use the resulting filename in the process tag. This makes it easy to quickly load it from cmd+click in the terminal when the run is complete.