### PR TITLE
conda: update channel priorities

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,8 +2,8 @@
 #   conda env create -f environment.yml
 name: nf-core-methylseq-1.4dev
 channels:
-  - bioconda
   - conda-forge
+  - bioconda
   - defaults
 dependencies:
   # Dependencies for FastQC


### PR DESCRIPTION
This simply changes channel priorities to follow upstream behavior:
https://github.com/bioconda/bioconda-recipes/pull/10924

No idea why, but environment solving is much faster with this change.

Also, I tried pinning the channels as suggested in https://github.com/nf-core/methylseq/issues/74 
but that made things worse again. It's a mystery to me.
