### PR TITLE
remove fastqc specific workaround

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,10 +6,6 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  # Dependencies for FastQC
-  - conda-forge::openjdk=8.0.144
-  - anaconda::font-ttf-dejavu-sans-mono=2.37
-  - fontconfig=2.12.6
   - fastqc=0.11.8
   # Default bismark pipeline
   - trim-galore=0.5.0


### PR DESCRIPTION
This commit removes the fastqc specific dependencies which should be resolved upstream since
https://github.com/bioconda/bioconda-recipes/pull/12616 was merged

Additionally it fixes the following:

* significantly speeds up the creation of conda environments
* with conda >4.6.7 building the environment failed with
`UnsatisfiableError: The following specifications were found to be in conflict:
  - anaconda::font-ttf-dejavu-sans-mono=2.37
Use "conda search <package> --info" to see the dependencies for each package.`