### PR TITLE
bismark: add support for hisat2 alignment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,8 @@ install:
 env:
   - ALIGNER=bismark ALIGNER_REF="--bismark_index ${TRAVIS_BUILD_DIR}/tests/results/reference_genome/BismarkIndex/" NXF_VER='0.32.0'
   - ALIGNER=bismark ALIGNER_REF="--bismark_index ${TRAVIS_BUILD_DIR}/tests/results/reference_genome/BismarkIndex/"
+  - ALIGNER=bismark_hisat ALIGNER_REF="--bismark_index ${TRAVIS_BUILD_DIR}/tests/results/reference_genome/BismarkIndex/" NXF_VER='0.32.0'
+  - ALIGNER=bismark_hisat ALIGNER_REF="--bismark_index ${TRAVIS_BUILD_DIR}/tests/results/reference_genome/BismarkIndex/"
   - ALIGNER=bwameth ALIGNER_REF="--bwa_meth_index ${TRAVIS_BUILD_DIR}/tests/results/reference_genome/genome.fa" NXF_VER='0.32.0'
   - ALIGNER=bwameth ALIGNER_REF="--bwa_meth_index ${TRAVIS_BUILD_DIR}/tests/results/reference_genome/genome.fa"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v1.4dev
 
 #### New features
+* Added support for running bismark with HISAT2 as an aligner option [#85](https://github.com/nf-core/methylseq/issues/85)
 * Added support for centralized configuration profiles [nf-core/configs](https://github.com/nf-core/configs)
 * Add `--meth_cutoff` parameter to change default for `bismark_methylation_extractor`
   * eg. use `--meth_cutoff 5` on the command line or `params.meth_cutoff = 5` to require 5 overlapping reads to call a methylation site.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v1.4dev
 
 #### New features
+* Added support for bismark's [SLAM-seq mode](https://github.com/FelixKrueger/Bismark/blob/master/CHANGELOG.md#slam-seq-mode)
 * Added support for running bismark with HISAT2 as an aligner option [#85](https://github.com/nf-core/methylseq/issues/85)
 * Added support for centralized configuration profiles [nf-core/configs](https://github.com/nf-core/configs)
 * Add `--meth_cutoff` parameter to change default for `bismark_methylation_extractor`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
   * eg. use `--meth_cutoff 5` on the command line or `params.meth_cutoff = 5` to require 5 overlapping reads to call a methylation site.
 * Added `--methylKit` option to run MethylDackel with the `--methylKit` flag, producing output suitable for the methylKit R package.
 
+#### Software updates
+* bismark `0.20.0` > `0.21.0`
+* _new dependency_: hisat2 `2.1.0` 
+
 #### Pipeline updates
 * Changed `params.container` for `process.container`
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The pipeline uses [Nextflow](https://www.nextflow.io), a bioinformatics workflow
 ### Pipeline Steps
 
 The pipeline allows you to choose between running either [Bismark](https://github.com/FelixKrueger/Bismark) or [bwa-meth](https://github.com/brentp/bwa-meth) / [MethylDackel](https://github.com/dpryan79/methyldackel).
-Choose between workflows by using `--aligner bismark` (default) or `--aligner bwameth`.
+Choose between workflows by using `--aligner bismark` (default, uses bowtie2 for alignment), `--aligner bismark_hisat` or `--aligner bwameth`.
 
 | Step                                         | Bismark workflow | bwa-meth workflow     |
 |----------------------------------------------|------------------|-----------------------|

--- a/docs/output.md
+++ b/docs/output.md
@@ -56,6 +56,7 @@ Single-end data will have slightly different file names and only one FastQ file 
 Bismark and bwa-meth convert all Cytosines contained within the sequenced reads to Thymine _in-silico_ and then align against a three-letter reference genome. This method avoids methylation-specific alignment bias. The alignment produces a BAM file of genomic alignments.
 
 **Bismark output directory: `results/bismark_alignments/`**
+_Note that bismark can use either use Bowtie2 (default) or HISAT2 as alignment tool and the output file names will not differ between the options._
 
 * `sample.bam`
   * Aligned reads in BAM format.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -33,6 +33,8 @@
     * [`--meth_cutoff`](#--meth_cutoff)
     * [`--ignoreFlags`](#--ignoreflags)
     * [`--methylKit`](#--methylKit)
+    * [`--known_splices`](#--known_splices)
+    * [`--slamseq`](#--slamseq) 
 * [Job Resources](#job-resources)
     * [Automatic resubmission](#automatic-resubmission)
     * [Maximum resource requests](#maximum-resource-requests)
@@ -260,6 +262,12 @@ Specify to run MethylDackel with the `--ignoreFlags` flag to ignore SAM flags.
 
 ### `--methylKit`
 Specify to run MethylDackel with the `--methylKit` flag to produce files suitable for use with the methylKit R package.
+
+### `--known_splices`
+Specify to run bismark with the `--known-splicesite-infile` flag to run splice-aware alignment using HISAT2. A textfile containing a list of known splicesites has to be provided. (only works with `--aligner bismark_hisat`)
+
+### `--slamseq`
+Specify to run bismark with the `--slam` flag to run bismark in [SLAM-seq mode](https://github.com/FelixKrueger/Bismark/blob/master/CHANGELOG.md#slam-seq-mode) (only works with `--aligner bismark_hisat`)
 
 
 ## Job Resources

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -49,9 +49,11 @@
 
 ## Bismark and bwa-meth workflow
 
-The nf-core/methylseq package is actually two pipelines in one. The default workflow uses [Bismark](http://www.bioinformatics.babraham.ac.uk/projects/bismark/): unless specified otherwise, nf-core/methylseq will run this pipeline.
+The nf-core/methylseq package is actually two pipelines in one. The default workflow uses [Bismark](http://www.bioinformatics.babraham.ac.uk/projects/bismark/) with [Bowtie2](http://bowtie-bio.sourceforge.net/bowtie2/index.shtml) as alignment tool: unless specified otherwise, nf-core/methylseq will run this pipeline.
 
-The second workflow uses [BWA-Meth](https://github.com/brentp/bwa-meth) and [MethylDackyl](https://github.com/dpryan79/methyldackel) instead of Bismark. To run this workflow, run the pipeline with the command line flag `--aligner bwameth`.
+Since bismark v0.21.0 it is also possible to use [HISAT2](https://ccb.jhu.edu/software/hisat2/index.shtml) as alignment tool. To run this workflow, invoke the pipeline with the command line flag `--aligner bismark_hisat`. HISAT2 also supports splice-aware alignment if analysis of RNA is desired (e.g. [SLAMseq](https://science.sciencemag.org/content/360/6390/800) experiments), a file containing a list of known splicesites can be provided with `--known_splices`.
+
+The second workflow uses [BWA-Meth](https://github.com/brentp/bwa-meth) and [MethylDackel](https://github.com/dpryan79/methyldackel) instead of Bismark. To run this workflow, run the pipeline with the command line flag `--aligner bwameth`.
 
 ## Running the pipeline
 The main command for running the pipeline is as follows:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -264,10 +264,10 @@ Specify to run MethylDackel with the `--ignoreFlags` flag to ignore SAM flags.
 Specify to run MethylDackel with the `--methylKit` flag to produce files suitable for use with the methylKit R package.
 
 ### `--known_splices`
-Specify to run bismark with the `--known-splicesite-infile` flag to run splice-aware alignment using HISAT2. A textfile containing a list of known splicesites has to be provided. (only works with `--aligner bismark_hisat`)
+Specify to run Bismark with the `--known-splicesite-infile` flag to run splice-aware alignment using HISAT2. A `.gtf` file has to be provided from which a list of known splicesites is created by the pipeline. (only works with `--aligner bismark_hisat`)
 
 ### `--slamseq`
-Specify to run bismark with the `--slam` flag to run bismark in [SLAM-seq mode](https://github.com/FelixKrueger/Bismark/blob/master/CHANGELOG.md#slam-seq-mode) (only works with `--aligner bismark_hisat`)
+Specify to run Bismark with the `--slam` flag to run bismark in [SLAM-seq mode](https://github.com/FelixKrueger/Bismark/blob/master/CHANGELOG.md#slam-seq-mode) (only works with `--aligner bismark_hisat`)
 
 
 ## Job Resources

--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,7 @@ dependencies:
   - trim-galore=0.5.0
   - samtools=1.9
   - bowtie2=2.3.4.3
-  - bismark=0.20.0
+  - bismark=0.21.0
   - qualimap=2.2.2b
   - preseq=2.0.3
   - multiqc=1.7

--- a/environment.yml
+++ b/environment.yml
@@ -7,6 +7,7 @@ channels:
   - defaults
 dependencies:
   - fastqc=0.11.8
+  - r-markdown=0.8
   # Default bismark pipeline
   - trim-galore=0.5.0
   - samtools=1.9

--- a/environment.yml
+++ b/environment.yml
@@ -11,6 +11,7 @@ dependencies:
   - trim-galore=0.5.0
   - samtools=1.9
   - bowtie2=2.3.4.3
+  - hisat2=2.1.0
   - bismark=0.21.0
   - qualimap=2.2.2b
   - preseq=2.0.3

--- a/main.nf
+++ b/main.nf
@@ -180,6 +180,7 @@ summary['Run Name']       = custom_runName ?: workflow.runName
 summary['Reads']          = params.reads
 summary['Aligner']        = params.aligner
 summary['Spliced alignment']  = params.known_splices ? 'Yes' : 'No'
+summary['SLAM-seq']  = params.slamseq ? 'Yes' : 'No'
 summary['Data Type']      = params.singleEnd ? 'Single-End' : 'Paired-End'
 summary['Genome']         = params.genome
 if( params.bismark_index ) summary['Bismark Index'] = params.bismark_index
@@ -258,10 +259,11 @@ if( !params.bismark_index && params.aligner =~ /bismark/ ){
 
         script:
         aligner = params.aligner == 'bismark_hisat' ? '--hisat2' : '--bowtie2'
+        slam = params.slamseq ? '--slam' : ''
         """
         mkdir BismarkIndex
         cp $fasta BismarkIndex/
-        bismark_genome_preparation $aligner BismarkIndex
+        bismark_genome_preparation $aligner $slam BismarkIndex
         """
     }
 }
@@ -404,7 +406,7 @@ if( params.aligner =~ /bismark/ ){
 
         script:
         aligner = params.aligner == "bismark_hisat" ? "--hisat2" : "--bowtie2"
-        splicesites = params.aligner == "bismark_hisat" && knownsplices.name != 'null' ? "--known-splicesite-infile ${splicesites}" : ''
+        splicesites = params.aligner == "bismark_hisat" && knownsplices.name != 'null' ? "--known-splicesite-infile ${knownsplices}" : ''
         pbat = params.pbat ? "--pbat" : ''
         non_directional = params.single_cell || params.zymo || params.non_directional ? "--non_directional" : ''
         unmapped = params.unmapped ? "--unmapped" : ''

--- a/main.nf
+++ b/main.nf
@@ -406,7 +406,7 @@ if( params.aligner =~ /bismark/ ){
 
         script:
         aligner = params.aligner == "bismark_hisat" ? "--hisat2" : "--bowtie2"
-        splicesites = params.aligner == "bismark_hisat" && knownsplices.name != 'null' ? "--known-splicesite-infile ${knownsplices}" : ''
+        splicesites = params.aligner == "bismark_hisat" && knownsplices.name != 'null' ? "--known-splicesite-infile <(hisat2_extract_splice_sites.py ${knownsplices})" : ''
         pbat = params.pbat ? "--pbat" : ''
         non_directional = params.single_cell || params.zymo || params.non_directional ? "--non_directional" : ''
         unmapped = params.unmapped ? "--unmapped" : ''

--- a/nextflow.config
+++ b/nextflow.config
@@ -15,6 +15,7 @@ params {
   // Pipeline options
   aligner = 'bismark'
   known_splices = false
+  slamseq = false
   saveReference = false
   saveTrimmed = false
   saveAlignedIntermediates = false

--- a/nextflow.config
+++ b/nextflow.config
@@ -14,6 +14,7 @@ params {
 
   // Pipeline options
   aligner = 'bismark'
+  known_splices = false
   saveReference = false
   saveTrimmed = false
   saveAlignedIntermediates = false


### PR DESCRIPTION
Addresses https://github.com/nf-core/methylseq/issues/85

Since bismark v0.21.0 , alignment using HISAT2 is supported in addition to Bowtie2.

As suggested by @ewels it can be run using `--aligner bismark_hisat`

I added the required steps for bismark_genome_preparation and bismark alignment. 
Supplying a file containing list of known splicesites should work as well with the `--known_splices` flag but is not very useful as of now because the pipeline can't handle RNA samples yet. We should probably also add support for bismark's `--slam` flag to make it more useful for SLAM-seq usecases.

Also there are some sanity checks missing to prevent breakage e.g if accidentally bowtie2 indices are supplied together with `--aligner bismark_hisat`. This can be done by checking the file endings I suppose.

