### PR TITLE
Bismark workflow: add option for local alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v1.4dev
 
 #### New features
+* Added `--local_alignment` option to run Bismark with the `--local` flag to allow soft-clipping of reads.
 * Added support for bismark's [SLAM-seq mode](https://github.com/FelixKrueger/Bismark/blob/master/CHANGELOG.md#slam-seq-mode)
 * Added support for running bismark with HISAT2 as an aligner option [#85](https://github.com/nf-core/methylseq/issues/85)
 * Added support for centralized configuration profiles [nf-core/configs](https://github.com/nf-core/configs)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -32,6 +32,7 @@
   * [`--methylKit`](#--methylKit)
   * [`--known_splices`](#--known_splices)
   * [`--slamseq`](#--slamseq)
+  * [`--local_alignment`](#--local_alignment)
 * [Reference genomes](#reference-genomes)
   * [`--genome` (using iGenomes)](#--genome-using-igenomes)
   * [`--igenomesIgnore`](#--igenomesignore)
@@ -308,6 +309,8 @@ Specify to run Bismark with the `--known-splicesite-infile` flag to run splice-a
 ### `--slamseq`
 Specify to run Bismark with the `--slam` flag to run bismark in [SLAM-seq mode](https://github.com/FelixKrueger/Bismark/blob/master/CHANGELOG.md#slam-seq-mode) (only works with `--aligner bismark_hisat`)
 
+### `--local_alignment`
+Specify to run Bismark with the `--local` flag to allow soft-clipping of reads. This should only be used with care in certain single-cell applications or PBAT libraries, which may produce chimeric read pairs. (See [Wu et al.](https://doi.org/10.1093/bioinformatics/btz125)
 
 ## Job Resources
 ### Automatic resubmission

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -310,7 +310,7 @@ Specify to run Bismark with the `--known-splicesite-infile` flag to run splice-a
 Specify to run Bismark with the `--slam` flag to run bismark in [SLAM-seq mode](https://github.com/FelixKrueger/Bismark/blob/master/CHANGELOG.md#slam-seq-mode) (only works with `--aligner bismark_hisat`)
 
 ### `--local_alignment`
-Specify to run Bismark with the `--local` flag to allow soft-clipping of reads. This should only be used with care in certain single-cell applications or PBAT libraries, which may produce chimeric read pairs. (See [Wu et al.](https://doi.org/10.1093/bioinformatics/btz125)
+Specify to run Bismark with the `--local` flag to allow soft-clipping of reads. This should only be used with care in certain single-cell applications or PBAT libraries, which may produce chimeric read pairs. (See [Wu et al.](https://doi.org/10.1093/bioinformatics/btz125) (doesn't work with `--aligner bwameth`)
 
 ## Job Resources
 ### Automatic resubmission

--- a/main.nf
+++ b/main.nf
@@ -44,6 +44,7 @@ def helpMessage() {
      --numMismatches        0.6 will allow a penalty of bp * -0.6 - for 100bp reads (bismark default is 0.2)
      --known_splices	Supply a .gtf file containing known splice sites (bismark_hisat only)
      --slamseq	Run bismark in SLAM-seq mode
+     --local_alignment Allow soft-clipping of reads (potentially useful for single-cell experiments)
 
     References                      If not specified in the configuration file or you wish to overwrite any of the references.
       --fasta                       Path to Fasta reference
@@ -250,6 +251,7 @@ summary['Reads']          = params.reads
 summary['Aligner']        = params.aligner
 summary['Spliced alignment']  = params.known_splices ? 'Yes' : 'No'
 summary['SLAM-seq']  = params.slamseq ? 'Yes' : 'No'
+summary['Local alignment']  = params.local_alignment ? 'Yes' : 'No'
 summary['Data Type']      = params.singleEnd ? 'Single-End' : 'Paired-End'
 summary['Genome']         = params.genome
 if( params.bismark_index ) summary['Bismark Index'] = params.bismark_index
@@ -533,6 +535,7 @@ if( params.aligner =~ /bismark/ ){
         non_directional = params.single_cell || params.zymo || params.non_directional ? "--non_directional" : ''
         unmapped = params.unmapped ? "--unmapped" : ''
         mismatches = params.relaxMismatches ? "--score_min L,0,-${params.numMismatches}" : ''
+        soft_clipping = params.local_alignment ? "--local" : ''
         multicore = ''
         if( task.cpus ){
             // Numbers based on recommendation by Felix for a typical mouse genome
@@ -563,6 +566,7 @@ if( params.aligner =~ /bismark/ ){
                 --bam $pbat $non_directional $unmapped $mismatches $multicore \\
                 --genome $index \\
                 $reads \\
+                $soft_clipping \\
                 $splicesites
             """
         } else {
@@ -572,6 +576,7 @@ if( params.aligner =~ /bismark/ ){
                 --genome $index \\
                 -1 ${reads[0]} \\
                 -2 ${reads[1]} \\
+                $soft_clipping \\
                 $splicesites
             """
         }

--- a/nextflow.config
+++ b/nextflow.config
@@ -28,6 +28,7 @@ params {
   saveAlignedIntermediates = false
   known_splices = false
   slamseq = false
+  local_alignment = false
   saveReference = false
   saveTrimmed = false
   singleEnd = false

--- a/parameters.settings.json
+++ b/parameters.settings.json
@@ -514,7 +514,7 @@
         {
             "name": "local_alignment",
             "label": "Soft-clipping of reads",
-            "usage": "Run bismark with --local flag Allow soft-clipping of reads (potentially useful for single-cell experiments)",
+            "usage": "Run bismark with --local flag to allow soft-clipping of reads (potentially useful for single-cell experiments)",
             "render": "none",
             "default_value": false,
             "type": "boolean",

--- a/parameters.settings.json
+++ b/parameters.settings.json
@@ -512,6 +512,15 @@
             "group": "Advanced: bismark_hisat workflow only"
         },
         {
+            "name": "local_alignment",
+            "label": "Soft-clipping of reads",
+            "usage": "Run bismark with --local flag Allow soft-clipping of reads (potentially useful for single-cell experiments)",
+            "render": "none",
+            "default_value": false,
+            "type": "boolean",
+            "group": "Advanced: bismark workflow only"
+        },
+        {
             "name": "relaxMismatches",
             "label": "Relax mismatches",
             "usage": "Turn on to relax stringency for alignment (set allowed penalty with --numMismatches)",


### PR DESCRIPTION
Paraphrased from [Bismark v0.22.0 changelog](https://github.com/FelixKrueger/Bismark/releases/tag/0.22.0):

Some library preps favor the generation of read chimeras which potentially decreases mapping efficiency in certain usecases; this can be mitigated by allowing for soft-clipping of reads as per Bismark v0.22.0.