### PR TITLE
Changed memory for samtools to be in GB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 
 #### Pipeline updates
+* Keep memory in GB for samtools, to avoid problems with unit conversion ([#99](https://github.com/nf-core/methylseq/issues/99))
 * Changed `params.container` for `process.container`
 * Merged TEMPLATE branch
 

--- a/main.nf
+++ b/main.nf
@@ -942,7 +942,7 @@ process preseq {
 
     script:
     def avail_mem = task.memory ? ((task.memory.toGiga() - 6) / task.cpus) : false
-    def sort_mem = avail_mem && avail_mem > 2 ? "-m $avail_mem"+"G" : ''
+    def sort_mem = avail_mem && avail_mem > 2 ? "-m ${avail_mem}G" : ''
     """
     samtools sort $bam \\
         -@ ${task.cpus} $sort_mem \\

--- a/main.nf
+++ b/main.nf
@@ -52,7 +52,7 @@ def helpMessage() {
       --bismark_index      Path to Bismark index
       --bwa_meth_index  Path to bwameth index
       --saveReference       Save reference(s) to results directory
-    
+
     Trimming options:
      --notrim   Skip read trimming
      --clip_r1  Trim the specified number of bases from the 5' end of read 1 (or single-end reads).
@@ -806,8 +806,8 @@ if( params.aligner == 'bwameth' ){
         file "where_are_my_files.txt"
 
         script:
-        def avail_mem = task.memory ? ((task.memory.toBytes() - 6000000000) / task.cpus) : false
-        def sort_mem = avail_mem && avail_mem > 2000000000 ? "-m $avail_mem" : ''
+        def avail_mem = task.memory ? ((task.memory.toGiga() - 6) / task.cpus) : false
+        def sort_mem = avail_mem && avail_mem > 2 ? "-m $avail_mem"+"G" : ''
         """
         samtools sort $bam \\
             -@ ${task.cpus} $sort_mem \\
@@ -912,8 +912,8 @@ process qualimap {
     script:
     gcref = params.genome == 'GRCh37' ? '-gd HUMAN' : ''
     gcref = params.genome == 'GRCm38' ? '-gd MOUSE' : ''
-    def avail_mem = task.memory ? ((task.memory.toBytes() - 6000000000) / task.cpus) : false
-    def sort_mem = avail_mem && avail_mem > 2000000000 ? "-m $avail_mem" : ''
+    def avail_mem = task.memory ? ((task.memory.toGiga() - 6) / task.cpus) : false
+    def sort_mem = avail_mem && avail_mem > 2 ? "-m $avail_mem"+"G" : ''
     """
     samtools sort $bam \\
         -@ ${task.cpus} $sort_mem \\
@@ -941,8 +941,8 @@ process preseq {
     file "${bam.baseName}.ccurve.txt" into preseq_results
 
     script:
-    def avail_mem = task.memory ? ((task.memory.toBytes() - 6000000000) / task.cpus) : false
-    def sort_mem = avail_mem && avail_mem > 2000000000 ? "-m $avail_mem" : ''
+    def avail_mem = task.memory ? ((task.memory.toGiga() - 6) / task.cpus) : false
+    def sort_mem = avail_mem && avail_mem > 2 ? "-m $avail_mem"+"G" : ''
     """
     samtools sort $bam \\
         -@ ${task.cpus} $sort_mem \\

--- a/main.nf
+++ b/main.nf
@@ -913,7 +913,7 @@ process qualimap {
     gcref = params.genome == 'GRCh37' ? '-gd HUMAN' : ''
     gcref = params.genome == 'GRCm38' ? '-gd MOUSE' : ''
     def avail_mem = task.memory ? ((task.memory.toGiga() - 6) / task.cpus) : false
-    def sort_mem = avail_mem && avail_mem > 2 ? "-m $avail_mem"+"G" : ''
+    def sort_mem = avail_mem && avail_mem > 2 ? "-m ${avail_mem}G" : ''
     """
     samtools sort $bam \\
         -@ ${task.cpus} $sort_mem \\

--- a/main.nf
+++ b/main.nf
@@ -807,7 +807,7 @@ if( params.aligner == 'bwameth' ){
 
         script:
         def avail_mem = task.memory ? ((task.memory.toGiga() - 6) / task.cpus) : false
-        def sort_mem = avail_mem && avail_mem > 2 ? "-m $avail_mem"+"G" : ''
+        def sort_mem = avail_mem && avail_mem > 2 ? "-m ${avail_mem}G" : ''
         """
         samtools sort $bam \\
             -@ ${task.cpus} $sort_mem \\


### PR DESCRIPTION
This is done mainly to ease our minds when it comes to memory transformations between GB, MB, KB and B. Our cluster doesn't agree with the Nextflow transformations, so it's nice to keep them at a bare minimum.  

- [x] Add to changelog