### PR TITLE
Updated software deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@
 
 * Keep memory in GB for samtools, to avoid problems with unit conversion ([#99](https://github.com/nf-core/methylseq/issues/99))
 * Changed `params.container` for `process.container`
-* Merged TEMPLATE branch
+* Synchronised with version 1.7 of the nf-core/tools template
 
 ### Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,12 @@
 ### Software updates
 
 * _new dependency_: hisat2 `2.1.0`
-* _new dependency_: r-markdown `0.9`
-* Bismark `0.20.0` > `0.22.1`
+* _new dependency_: r-markdown `1.1`
+* TrimGalore! `0.5.0` > `0.6.4`
+* Bismark `0.20.0` > `0.22.2`
 * Bowtie2 `2.3.4.3` > `2.3.5`
-* Picard `2.18.21` > `2.19.1`
+* Picard `2.18.21` > `2.21.3`
+* Qualimap `2.2.2b` > `2.2.2c`
 * MethylDackel `0.3.0` > `0.4.0`
 
 ### Pipeline updates

--- a/environment.yml
+++ b/environment.yml
@@ -7,17 +7,17 @@ channels:
   - defaults
 dependencies:
   - bioconda::fastqc=0.11.8
-  - conda-forge::r-markdown=0.9
+  - conda-forge::r-markdown=1.1
   # Default bismark pipeline
-  - bioconda::trim-galore=0.5.0
+  - bioconda::trim-galore=0.6.4
   - bioconda::samtools=1.9
   - bioconda::bowtie2=2.3.5
   - bioconda::hisat2=2.1.0
-  - bioconda::bismark=0.22.1
-  - bioconda::qualimap=2.2.2b
+  - bioconda::bismark=0.22.2
+  - bioconda::qualimap=2.2.2c
   - bioconda::preseq=2.0.3
   - bioconda::multiqc=1.7
   # bwa-meth pipeline
-  - bioconda::picard=2.19.1
+  - bioconda::picard=2.21.3
   - bioconda::bwameth=0.2.2
   - bioconda::methyldackel=0.4.0


### PR DESCRIPTION
```diff
   - defaults
 dependencies:
   - bioconda::fastqc=0.11.8
-  - conda-forge::r-markdown=0.9
+  - conda-forge::r-markdown=1.1
   # Default bismark pipeline
-  - bioconda::trim-galore=0.5.0
+  - bioconda::trim-galore=0.6.4
   - bioconda::samtools=1.9
   - bioconda::bowtie2=2.3.5
   - bioconda::hisat2=2.1.0
-  - bioconda::bismark=0.22.1
+  - bioconda::bismark=0.22.2
-  - bioconda::qualimap=2.2.2b
+  - bioconda::qualimap=2.2.2c
   - bioconda::preseq=2.0.3
   - bioconda::multiqc=1.7
   # bwa-meth pipeline
-  - bioconda::picard=2.19.1
+  - bioconda::picard=2.21.3
   - bioconda::bwameth=0.2.2
   - bioconda::methyldackel=0.4.0
```