### PR TITLE
fix bug introduced by https://github.com/nf-core/methylseq/pull/113

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -908,8 +908,8 @@ process qualimap {
     file "${bam.baseName}_qualimap" into ch_qualimap_results_for_multiqc
 
     script:
-    gcref = params.genome.contains('GRCh') ? '-gd HUMAN' : ''
-    gcref = params.genome.contains('GRCm') ? '-gd MOUSE' : ''
+    gcref = params.genome.toString().startsWith('GRCh') ? '-gd HUMAN' : ''
+    gcref = params.genome.toString().startsWith('GRCm') ? '-gd MOUSE' : ''
     def avail_mem = task.memory ? ((task.memory.toGiga() - 6) / task.cpus).trunc() : false
     def sort_mem = avail_mem && avail_mem > 2 ? "-m ${avail_mem}G" : ''
     """


### PR DESCRIPTION
converts `params.genome` to a string before applying a string function :man_facepalming: 