### PR TITLE
iGenomes fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Pipeline Updates
 
+* Fixed bug where the iGenomes config was loaded after the references were set ([#121](https://github.com/nf-core/methylseq/issues/121))
 * Removed awsbatch config profile because it is now served by [nf-core/configs](https://github.com/nf-core/configs)
 
 ## [v1.4](https://github.com/nf-core/methylseq/releases/tag/1.4) - 2019-11-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New features
 
 * Added multicore support for `TrimGalore!`
+* Improved the multicore support for Bismark methXtract for more parallelisation ([#121](https://github.com/nf-core/methylseq/issues/121))
 
 ### Software updates
 

--- a/conf/base.config
+++ b/conf/base.config
@@ -28,7 +28,7 @@ process {
   }
   withName:trim_galore {
     cpus = { check_max( 15 * task.attempt, 'cpus') }
-    memory = { check_max( 16.GB * task.attempt, 'memory') }
+    memory = { check_max( 6.GB * task.attempt, 'memory') }
     time = { check_max( 1.d * task.attempt, 'time') }
   }
   withName:bismark_align {

--- a/environment.yml
+++ b/environment.yml
@@ -6,6 +6,7 @@ channels:
   - bioconda
   - defaults
 dependencies:
+  - python=3.7
   - conda-forge::pigz=2.3.4
   - conda-forge::r-markdown=1.1
   - bioconda::fastqc=0.11.8

--- a/main.nf
+++ b/main.nf
@@ -94,6 +94,12 @@ assert params.aligner == 'bwameth' || params.aligner == 'bismark' || params.alig
  * SET UP CONFIGURATION VARIABLES
  */
 
+// These params need to be set late, after the iGenomes config is loaded
+bismark_index = params.genome ? params.genomes[ params.genome ].bismark ?: false : false
+bwa_meth_index = params.genome ? params.genomes[ params.genome ].bwa_meth ?: false : false
+fasta = params.genome ? params.genomes[ params.genome ].fasta ?: false : false
+fasta_index = params.genome ? params.genomes[ params.genome ].fasta_index ?: false : false
+
 // Check if genome exists in the config file
 if (params.genomes && params.genome && !params.genomes.containsKey(params.genome)) {
     exit 1, "The provided genome '${params.genome}' is not available in the iGenomes file. Currently the available genomes are ${params.genomes.keySet().join(", ")}"

--- a/nextflow.config
+++ b/nextflow.config
@@ -13,10 +13,6 @@ params {
   reads = "data/*_R{1,2}.fastq.gz"
   single_end = false
   aligner = 'bismark'
-  bismark_index = params.genome ? params.genomes[ params.genome ].bismark ?: false : false
-  bwa_meth_index = params.genome ? params.genomes[ params.genome ].bwa_meth ?: false : false
-  fasta = params.genome ? params.genomes[ params.genome ].fasta ?: false : false
-  fasta_index = params.genome ? params.genomes[ params.genome ].fasta_index ?: false : false
   comprehensive = false
   ignore_flags = false
   meth_cutoff = false


### PR DESCRIPTION
Fixes #121 by moving the reference genome `params` back in to `main.nf`. This means that they are set after the iGenomes config is loaded.