### PR TITLE
Pseudo-change to test new docker image for MultiQC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 * Added multicore support for `TrimGalore!`
 * Improved the multicore support for Bismark methXtract for more parallelisation ([#121](https://github.com/nf-core/methylseq/issues/121))
-* Added options `--bismark_align_cpu_per_multicore` and `--bismark_align_cpu_per_multicore` to customise how Bismark align `--multicore` is decided ([#124](https://github.com/nf-core/methylseq/issues/124)).
+* Added options `--bismark_align_cpu_per_multicore` and `--bismark_align_cpu_per_multicore` to customise how Bismark align `--multicore` is decided ([#124](https://github.com/nf-core/methylseq/issues/124))
 
 ### Software updates
 


### PR DESCRIPTION
Fake pull request with a trivial changelog change. This is to run the CI tests on the new docker image, built with the reverted MultiQC v1.7 - see https://hub.docker.com/repository/registry-1.docker.io/nfcore/methylseq/builds/d0852faa-f198-4d43-96c0-93d025323db1

Hopefully everything should work now, then we can go for a minor release. Once that's out we can revisit Python 3k and MultiQC v1.8.