### PR TITLE
Added params to ref paths.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
 
 before_install:
   # PRs to master are only ok if coming from dev branch
-  - '[ $TRAVIS_PULL_REQUEST = "false" ] || [ $TRAVIS_BRANCH != "master" ] || ([ $TRAVIS_PULL_REQUEST_SLUG = $TRAVIS_REPO_SLUG ] && [ $TRAVIS_PULL_REQUEST_BRANCH = "dev" ]) || [ $TRAVIS_PULL_REQUEST_BRANCH = "patch" ]'
+  - '[ $TRAVIS_PULL_REQUEST = "false" ] || [ $TRAVIS_BRANCH != "master" ] || ([ $TRAVIS_PULL_REQUEST_SLUG = $TRAVIS_REPO_SLUG ] && ([ $TRAVIS_PULL_REQUEST_BRANCH = "dev" ] || [ $TRAVIS_PULL_REQUEST_BRANCH = "patch" ]))'
   # Pull the docker image first so the test doesn't wait for this
   - docker pull nfcore/methylseq:dev
   # Fake the tag locally so that the pipeline runs properly

--- a/main.nf
+++ b/main.nf
@@ -97,10 +97,10 @@ assert params.aligner == 'bwameth' || params.aligner == 'bismark' || params.alig
  */
 
 // These params need to be set late, after the iGenomes config is loaded
-bismark_index = params.genome ? params.genomes[ params.genome ].bismark ?: false : false
-bwa_meth_index = params.genome ? params.genomes[ params.genome ].bwa_meth ?: false : false
-fasta = params.genome ? params.genomes[ params.genome ].fasta ?: false : false
-fasta_index = params.genome ? params.genomes[ params.genome ].fasta_index ?: false : false
+params.bismark_index = params.genome ? params.genomes[ params.genome ].bismark ?: false : false
+params.bwa_meth_index = params.genome ? params.genomes[ params.genome ].bwa_meth ?: false : false
+params.fasta = params.genome ? params.genomes[ params.genome ].fasta ?: false : false
+params.fasta_index = params.genome ? params.genomes[ params.genome ].fasta_index ?: false : false
 
 // Check if genome exists in the config file
 if (params.genomes && params.genome && !params.genomes.containsKey(params.genome)) {


### PR DESCRIPTION
Fixes error pointed out by @efratushava in https://github.com/nf-core/methylseq/issues/121#issuecomment-561759582

Basically in the `nextflow.config` file we had these under the `params` scope. We copied and pasted them into `main.nf` but without that scope.

Also, this PR should check that the new docker build is working. Hopefully the last PR needed before the new minor release.