### PR TITLE
Bump conda software versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # nf-core/methylseq
 
-## [v1.4.1](https://github.com/nf-core/methylseq/releases/tag/1.4.1) - 2019-12-11
+## [v1.4.1](https://github.com/nf-core/methylseq/releases/tag/1.4.1) - 2020-04-08
 
 ### New features
 
@@ -12,11 +12,16 @@
 ### Software updates
 
 * _new dependency_: pigz `2.3.4`
-* Python base `2.7` > `3.7.3`
+* Python base `2.7` > `3.8.2`
+* FastQC `0.11.8` > `0.11.9`
 * TrimGalore! `0.6.4` > `0.6.5`
+* Bowtie2 `2.3.5` > `2.4.1`
+* HiSAT2 `2.1.0` > `2.2.0`
 * Bismark `0.22.2` > `0.22.3`
 * Qualimap `2.2.2c` > `2.2.2d`
-* Picard `2.21.3` > `2.21.4`
+* Samtools `1.9` > `1.10`
+* Picard `2.21.3` > `2.22.2`
+* MethylDackel `0.4.0` > `0.5.0`
 * MultiQC `1.7` > `1.8`
 
 ### Pipeline Updates

--- a/environment.yml
+++ b/environment.yml
@@ -7,22 +7,22 @@ channels:
   - defaults
 dependencies:
   # nf-core dependencies
-  - conda-forge::python=3.7.3
-  - conda-forge::markdown=3.1.1
+  - conda-forge::python=3.8.2
+  - conda-forge::markdown=3.2.1
   - conda-forge::pymdown-extensions=6.0
-  - conda-forge::pygments=2.5.2
+  - conda-forge::pygments=2.6.1
   - conda-forge::pigz=2.3.4
-  - bioconda::fastqc=0.11.8
+  - bioconda::fastqc=0.11.9
   # Default bismark pipeline
   - bioconda::trim-galore=0.6.5
-  - bioconda::samtools=1.9
-  - bioconda::bowtie2=2.3.5
-  - bioconda::hisat2=2.1.0
+  - bioconda::samtools=1.10
+  - bioconda::bowtie2=2.4.1
+  - bioconda::hisat2=2.2.0
   - bioconda::bismark=0.22.3
   - bioconda::qualimap=2.2.2d
   - bioconda::preseq=2.0.3
   - bioconda::multiqc=1.8
   # bwa-meth pipeline
-  - bioconda::picard=2.21.4
+  - bioconda::picard=2.22.2
   - bioconda::bwameth=0.2.2
-  - bioconda::methyldackel=0.4.0
+  - bioconda::methyldackel=0.5.0


### PR DESCRIPTION
Software version bump for release v1.5. See https://github.com/nf-core/methylseq/pull/133 for details.