### PR TITLE
Downgrade python, bowtie2 and samtools to get conda env to build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,14 +12,12 @@
 ### Software updates
 
 * _new dependency_: pigz `2.3.4`
-* Python base `2.7` > `3.8.2`
+* Python base `2.7` > `3.7.3`
 * FastQC `0.11.8` > `0.11.9`
 * TrimGalore! `0.6.4` > `0.6.5`
-* Bowtie2 `2.3.5` > `2.4.1`
 * HiSAT2 `2.1.0` > `2.2.0`
 * Bismark `0.22.2` > `0.22.3`
 * Qualimap `2.2.2c` > `2.2.2d`
-* Samtools `1.9` > `1.10`
 * Picard `2.21.3` > `2.22.2`
 * MethylDackel `0.4.0` > `0.5.0`
 * MultiQC `1.7` > `1.8`

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ channels:
   - defaults
 dependencies:
   # nf-core dependencies
-  - conda-forge::python=3.8.2
+  - conda-forge::python=3.7.3
   - conda-forge::markdown=3.2.1
   - conda-forge::pymdown-extensions=6.0
   - conda-forge::pygments=2.6.1
@@ -15,8 +15,8 @@ dependencies:
   - bioconda::fastqc=0.11.9
   # Default bismark pipeline
   - bioconda::trim-galore=0.6.5
-  - bioconda::samtools=1.10
-  - bioconda::bowtie2=2.4.1
+  - bioconda::samtools=1.9
+  - bioconda::bowtie2=2.3.5
   - bioconda::hisat2=2.2.0
   - bioconda::bismark=0.22.3
   - bioconda::qualimap=2.2.2d


### PR DESCRIPTION
See https://github.com/nf-core/methylseq/pull/152#issuecomment-610431826 - upgrading all packages caused a failure in the conda / docker build.

Testing locally, reverting these package updates fixes the build.