### PR TITLE
add action to build conda environment upon changes

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -1,0 +1,17 @@
+name: conda CI
+
+on:
+  pull_request:
+    # run only if environment.yml changed
+    paths:
+      - 'environment.yml'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - uses: actions/checkout@v2
+      - uses: docker://continuumio/miniconda3:4.8.2
+      - name: Build conda environment
+        run: conda env create -f ${GITHUB_WORKSPACE}/environment.yml

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -12,6 +12,6 @@ jobs:
     
     steps:
       - uses: actions/checkout@v2
-      - uses: docker://continuumio/miniconda3:4.8.2
+      - uses: docker://nfcore/base:latest
       - name: Build conda environment
         run: conda env create -f ${GITHUB_WORKSPACE}/environment.yml


### PR DESCRIPTION
Many thanks to contributing to nf-core/methylseq!

Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs).

## PR checklist
 - [ ] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If necessary, also make a PR on the [nf-core/methylseq branch on the nf-core/test-datasets repo]( https://github.com/nf-core/test-datasets/pull/new/nf-core/methylseq)
 - [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [ ] Make sure your code lints (`nf-core lint .`).
 - [ ] Documentation in `docs` is updated
 - [ ] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated

**Learn more about contributing:** https://github.com/nf-core/methylseq/tree/master/.github/CONTRIBUTING.md


This is more of a proposal:

Currently, the docker build is only triggered _after_ a merge commit, which has caused problems in the past when the build failed (particularly when bumping versions of conda packages).

This action triggers a test build of the updated conda environment, _if_ `environment.yml` has changed.

Assuming that:

* docker build failures are likely caused by conda version conflicts
* all nf-core pipelines follow this mechanism of baking a conda env into a docker container

.. I believe this could improve our chances of catching such problems earlier, before a broken container causes further problems. So I propose adding such an action for all pipelines via an upcoming template sync

