### PR TITLE
Usage md notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 [![Docker](https://img.shields.io/docker/automated/nfcore/methylseq.svg)](https://hub.docker.com/r/nfcore/methylseq)
 [![Get help on Slack](http://img.shields.io/badge/slack-nf--core%20%23methylseq-4A154B?logo=slack)](https://nfcore.slack.com/channels/methylseq)
 
+## Introduction
+
 nf-core/methylseq is a bioinformatics analysis pipeline used for Methylation (Bisulfite) sequencing data. It pre-processes raw data from FastQ inputs, aligns the reads and performs extensive quality-control on the results.
 
 The pipeline is built using [Nextflow](https://www.nextflow.io), a workflow tool to run tasks across multiple compute infrastructures in a very portable manner. It comes with docker containers making installation trivial and results highly reproducible.

--- a/docs/output.md
+++ b/docs/output.md
@@ -1,5 +1,13 @@
 # nf-core/methylseq Output
 
+**:warning: Please read this documentation on the nf-core website: https://nf-co.re/methylseq**
+
+Documentation of pipeline parameters is generated automatically from the pipeline schema and can no longer be found in markdown files.
+
+## Introduction
+
+Documentation of pipeline parameters is generated automatically from the pipeline schema and can no longer be found in markdown files.
+
 This document describes the output produced by the pipeline. Most of the plots are taken from the MultiQC report, which summarises results at the end of the pipeline.
 
 Note that nf-core/methylseq contains two workflows - one for Bismark, one for bwa-meth. The results files produced will vary depending on which variant is run.
@@ -189,7 +197,7 @@ For more information about how to use MultiQC reports, see [https://multiqc.info
 
 **Output files:**
 
-* `multiqc/`  
+* `multiqc/`
   * `multiqc_report.html`: a standalone HTML file that can be viewed in your web browser.
   * `multiqc_data/`: directory containing parsed statistics from the different tools used in the pipeline.
   * `multiqc_plots/`: directory containing static images from the report in various formats.

--- a/docs/output.md
+++ b/docs/output.md
@@ -1,8 +1,8 @@
 # nf-core/methylseq Output
 
-**:warning: Please read this documentation on the nf-core website: https://nf-co.re/methylseq**
+## :warning: Please read this documentation on the nf-core website: https://nf-co.re/methylseq :warning:
 
-Documentation of pipeline parameters is generated automatically from the pipeline schema and can no longer be found in markdown files.
+> _Documentation of pipeline parameters is generated automatically from the pipeline schema and can no longer be found in markdown files._
 
 ## Introduction
 

--- a/docs/output.md
+++ b/docs/output.md
@@ -1,6 +1,6 @@
 # nf-core/methylseq Output
 
-## :warning: Please read this documentation on the nf-core website: https://nf-co.re/methylseq :warning:
+## :warning: Please read this documentation on the nf-core website: [https://nf-co.re/methylseq](https://nf-co.re/methylseq) :warning:
 
 > _Documentation of pipeline parameters is generated automatically from the pipeline schema and can no longer be found in markdown files._
 

--- a/docs/output.md
+++ b/docs/output.md
@@ -1,6 +1,6 @@
 # nf-core/methylseq Output
 
-## :warning: Please read this documentation on the nf-core website: [https://nf-co.re/methylseq](https://nf-co.re/methylseq) :warning:
+## :warning: Please read this documentation on the nf-core website: [https://nf-co.re/methylseq](https://nf-co.re/methylseq)
 
 > _Documentation of pipeline parameters is generated automatically from the pipeline schema and can no longer be found in markdown files._
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,6 +1,6 @@
 # nf-core/methylseq: Usage
 
-## :warning: Please read this documentation on the nf-core website: https://nf-co.re/methylseq :warning:
+## :warning: Please read this documentation on the nf-core website: [https://nf-co.re/methylseq](https://nf-co.re/methylseq) :warning:
 
 > _Documentation of pipeline parameters is generated automatically from the pipeline schema and can no longer be found in markdown files._
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,6 +1,6 @@
 # nf-core/methylseq: Usage
 
-## :warning: Please read this documentation on the nf-core website: [https://nf-co.re/methylseq](https://nf-co.re/methylseq) :warning:
+## :warning: Please read this documentation on the nf-core website: [https://nf-co.re/methylseq](https://nf-co.re/methylseq)
 
 > _Documentation of pipeline parameters is generated automatically from the pipeline schema and can no longer be found in markdown files._
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,8 +1,8 @@
 # nf-core/methylseq: Usage
 
-**:warning: Please read this documentation on the nf-core website: https://nf-co.re/methylseq**
+## :warning: Please read this documentation on the nf-core website: https://nf-co.re/methylseq :warning:
 
-Documentation of pipeline parameters is generated automatically from the pipeline schema and can no longer be found in markdown files.
+> _Documentation of pipeline parameters is generated automatically from the pipeline schema and can no longer be found in markdown files._
 
 ## Table of contents
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,5 +1,9 @@
 # nf-core/methylseq: Usage
 
+**:warning: Please read this documentation on the nf-core website: https://nf-co.re/methylseq**
+
+Documentation of pipeline parameters is generated automatically from the pipeline schema and can no longer be found in markdown files.
+
 ## Table of contents
 
 * [Table of contents](#table-of-contents)


### PR DESCRIPTION
See https://github.com/nf-core/tools/issues/727

Adds a notice to the top of the markdown files telling people to read them on the nf-core website instead. Not visible on the nf-core website.

I also added an `## Introduction` header to the main repo readme, which stops the pipeline logo and badges from rendering on the website pipeline front-page.