### PR TITLE
Added new parameters --minins and --maxins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Updated template to tools 1.11
 * Moved parameter documentation into new `nextflow_schema.json` file.
+* Added new `--maxins` and `--minins` parameters to pass on to Bismark
 
 ## [v1.5](https://github.com/nf-core/methylseq/releases/tag/1.5) - 2020-04-09
 

--- a/main.nf
+++ b/main.nf
@@ -72,6 +72,7 @@ def helpMessage() {
      --accell [bool]
      --zymo [bool]
      --cegx [bool]
+     --em_seq [bool]
 
     Other options:
       --outdir [file]                 The output directory where the results will be saved
@@ -173,11 +174,13 @@ if (!(workflow.runName ==~ /[a-z]+_[a-z]+/)) {
     custom_runName = workflow.runName
 }
 
-// Trimming presets
+// Trimming / kit presets
 clip_r1 = params.clip_r1
 clip_r2 = params.clip_r2
 three_prime_clip_r1 = params.three_prime_clip_r1
 three_prime_clip_r2 = params.three_prime_clip_r2
+bismark_minins = params.minins
+bismark_maxins = params.maxins
 if(params.pbat){
     clip_r1 = 9
     clip_r2 = 9
@@ -207,6 +210,13 @@ else if( params.cegx ){
     clip_r2 = 6
     three_prime_clip_r1 = 2
     three_prime_clip_r2 = 2
+}
+else if( params.em_seq ){
+    bismark_maxins = 1000
+    clip_r1 = 8
+    clip_r2 = 8
+    three_prime_clip_r1 = 8
+    three_prime_clip_r2 = 8
 }
 
 // Check AWS batch settings
@@ -275,6 +285,7 @@ if(params.epignome)         summary['Trim Profile'] = 'TruSeq (EpiGnome)'
 if(params.accel)            summary['Trim Profile'] = 'Accel-NGS (Swift)'
 if(params.zymo)             summary['Trim Profile'] = 'Zymo Pico-Methyl'
 if(params.cegx)             summary['Trim Profile'] = 'CEGX'
+if(params.em_seq)           summary['Trim Profile'] = 'EM Seq'
 summary['Trimming']         = "5'R1: $clip_r1 / 5'R2: $clip_r2 / 3'R1: $three_prime_clip_r1 / 3'R2: $three_prime_clip_r2"
 summary['Deduplication']    = params.skip_deduplication || params.rrbs ? 'No' : 'Yes'
 summary['Directional Mode'] = params.single_cell || params.zymo || params.non_directional ? 'No' : 'Yes'
@@ -289,6 +300,8 @@ if(params.save_trimmed)     save_intermeds.add('Trimmed FastQ files')
 if(params.unmapped)         save_intermeds.add('Unmapped reads')
 if(params.save_align_intermeds) save_intermeds.add('Intermediate BAM files')
 if(save_intermeds.size() > 0) summary['Save Intermediates'] = save_intermeds.join(', ')
+if(params.minins)           summary['Bismark min insert size'] = bismark_minins
+if(params.maxins || params.em_seq) summary['Bismark max insert size'] = bismark_maxins
 if(params.bismark_align_cpu_per_multicore) summary['Bismark align CPUs per --multicore'] = params.bismark_align_cpu_per_multicore
 if(params.bismark_align_mem_per_multicore) summary['Bismark align memory per --multicore'] = params.bismark_align_mem_per_multicore
 summary['Output dir']       = params.outdir
@@ -564,8 +577,8 @@ if( params.aligner =~ /bismark/ ){
         unmapped = params.unmapped ? "--unmapped" : ''
         mismatches = params.relax_mismatches ? "--score_min L,0,-${params.num_mismatches}" : ''
         soft_clipping = params.local_alignment ? "--local" : ''
-        minins = params.minins ? "--minins ${params.minins}" : ''
-        maxins = params.maxins ? "--maxins ${params.maxins}" : ''
+        minins = bismark_minins ? "--minins $bismark_minins" : ''
+        maxins = bismark_maxins ? "--maxins $bismark_maxins" : ''
 
         // Try to assign sensible bismark memory units according to what the task was given
         multicore = ''

--- a/main.nf
+++ b/main.nf
@@ -45,6 +45,8 @@ def helpMessage() {
      --known_splices [file]             Supply a .gtf file containing known splice sites (bismark_hisat only)
      --slamseq [bool]                   Run bismark in SLAM-seq mode
      --local_alignment [bool]           Allow soft-clipping of reads (potentially useful for single-cell experiments)
+     --minins [int]                     Bismark: The minimum insert size for valid paired-end alignments.
+     --maxins [int]                     Bismark: The maximum insert size for valid paired-end alignments.
      --bismark_align_cpu_per_multicore [int] Specify how many CPUs are required per --multicore for bismark align (default = 3)
      --bismark_align_mem_per_multicore [str] Specify how much memory is required per --multicore for bismark align (default = 13.GB)
 
@@ -562,6 +564,8 @@ if( params.aligner =~ /bismark/ ){
         unmapped = params.unmapped ? "--unmapped" : ''
         mismatches = params.relax_mismatches ? "--score_min L,0,-${params.num_mismatches}" : ''
         soft_clipping = params.local_alignment ? "--local" : ''
+        minins = params.minins ? "--minins ${params.minins}" : ''
+        maxins = params.maxins ? "--maxins ${params.maxins}" : ''
 
         // Try to assign sensible bismark memory units according to what the task was given
         multicore = ''
@@ -600,7 +604,7 @@ if( params.aligner =~ /bismark/ ){
         """
         bismark $input \\
             $aligner \\
-            --bam $pbat $non_directional $unmapped $mismatches $multicore \\
+            --bam $pbat $non_directional $unmapped $mismatches $multicore $minins $maxins \\
             --genome $index \\
             $reads \\
             $soft_clipping \\

--- a/nextflow.config
+++ b/nextflow.config
@@ -38,6 +38,8 @@ params {
   known_splices = false
   slamseq = false
   local_alignment = false
+  minins = false
+  maxins = false
   save_reference = false
   save_trimmed = false
   unmapped = false

--- a/nextflow.config
+++ b/nextflow.config
@@ -24,6 +24,7 @@ params {
   accel = false
   zymo = false
   cegx = false
+  em_seq = false
   comprehensive = false
   cytosine_report = false
   ignore_flags = false

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -101,6 +101,12 @@
                     "fa_icon": "fas fa-wave-square",
                     "help_text": "Specify to run Bismark with the `--slam` flag to run bismark in [SLAM-seq mode](https://github.com/FelixKrueger/Bismark/blob/master/CHANGELOG.md#slam-seq-mode) \n\n> NB: Only works with when using the `bismark_hisat` aligner (`--aligner bismark_hisat`)"
                 },
+                "em_seq": {
+                    "type": "string",
+                    "fa_icon": "fas fa-cubes",
+                    "description": "Preset for EM-seq libraries.",
+                    "help_text": "Equivalent to `--clip_r1 8` `--clip_r2 8` `--three_prime_clip_r1 8` `--three_prime_clip_r2 8`.\n\nAlso sets the `--maxins` flag to `1000` for Bismark."
+                },
                 "single_cell": {
                     "type": "boolean",
                     "fa_icon": "fas fa-cut",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -288,6 +288,18 @@
                     "help_text": "Specify to run Bismark with the `--local` flag to allow soft-clipping of reads. This should only be used with care in certain single-cell applications or PBAT libraries, which may produce chimeric read pairs. (See [Wu et al.](https://doi.org/10.1093/bioinformatics/btz125)).",
                     "fa_icon": "fas fa-search"
                 },
+                "minins": {
+                    "type": "integer",
+                    "fa_icon": "fas fa-compress-alt",
+                    "description": "The minimum insert size for valid paired-end alignments.",
+                    "help_text": "For example, if `--minins 60` is specified and a paired-end alignment consists of two 20-bp alignments in the appropriate orientation with a 20-bp gap between them, that alignment is considered valid (as long as `--maxins` is also satisfied). A 19-bp gap would not be valid in that case.\n\nDefault: no flag (Bismark default: `0`)."
+                },
+                "maxins": {
+                    "type": "integer",
+                    "fa_icon": "fas fa-expand-alt",
+                    "description": "The maximum insert size for valid paired-end alignments.",
+                    "help_text": "For example, if `--maxins 100` is specified and a paired-end alignment consists of two 20-bp alignments in the proper orientation with a 60-bp gap between them, that alignment is considered valid (as long as `--minins` is also satisfied). A 61-bp gap would not be valid in that case.\n\nDefault: not specified. Bismark default: `500`."
+                },
                 "bismark_align_cpu_per_multicore": {
                     "type": "integer",
                     "default": 3,


### PR DESCRIPTION
Added new parameters `--minins` and `--maxins` to the pipeline, passed on to Bismark. These are needed to process EM-seq libraries.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Make sure your code lints (`nf-core lint .`).
- [x] Documentation in `docs` is updated
- [x] `CHANGELOG.md` is updated