### PR TITLE
Methylseq: Convert parameter docs to JSON schema

### DIFF
--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -1,0 +1,485 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "https://raw.githubusercontent.com/nf-core/methylseq/master/nextflow_schema.json",
+    "title": "nf-core/methylseq pipeline parameters",
+    "description": "Methylation (Bisulfite-Sequencing) Best Practice analysis pipeline, part of the nf-core community.",
+    "type": "object",
+    "definitions": {
+        "input_output_options": {
+            "title": "Input/output options",
+            "type": "object",
+            "fa_icon": "fas fa-terminal",
+            "description": "Define where the pipeline should find input data and save output data.",
+            "properties": {
+                "reads": {
+                    "type": "string",
+                    "default": "data/*_R{1,2}.fastq.gz",
+                    "description": "Path to input data (must be surrounded with quotes).",
+                    "help_text": "Use this to specify the location of your input FastQ files. For example:\n\n```bash\n--reads 'path/to/data/sample_*_{1,2}.fastq'\n```\n\nPlease note the following requirements:\n\n1. The path must be enclosed in quotes\n2. The path must have at least one `*` wildcard character\n3. When using the pipeline with paired end data, the path must use `{1,2}` notation to specify read pairs.\n\nIf left unspecified, a default pattern is used: `data/*{1,2}.fastq.gz`\n",
+                    "fa_icon": "fas fa-copy"
+                },
+                "single_end": {
+                    "type": "boolean",
+                    "description": "Specifies that the input is single-end reads.",
+                    "fa_icon": "fas fa-align-center",
+                    "help_text": "By default, the pipeline expects paired-end data. If you have single-end data, you need to specify `--single_end` on the command line when you launch the pipeline. A normal glob pattern, enclosed in quotation marks, can then be used for `--input`. For example:\n\n```bash\n--single_end --input '*.fastq'\n```\n\nIt is not possible to run a mixture of single-end and paired-end files in one run."
+                },
+                "comprehensive": {
+                    "type": "boolean",
+                    "description": "Output information for all cytosine contexts.",
+                    "help_text": "By default, the pipeline only produces data for cytosine methylation states in CpG context. Specifying `--comprehensive` makes the pipeline give results for all cytosine contexts. Note that for large genomes (e.g. Human), these can be massive files. This is only recommended for small genomes (especially those that don't exhibit strong CpG context methylation specificity).\n\nIf specified, this flag instructs the Bismark methylation extractor to use the `--comprehensive` and `--merge_non_CpG` flags. This produces coverage files with information from about all strands and cytosine contexts merged into two files - one for CpG context and one for non-CpG context.\n\nIf using the bwa-meth workflow, the flag makes MethylDackel report CHG and CHH contexts as well.\n",
+                    "fa_icon": "fas fa-stream"
+                },
+                "outdir": {
+                    "type": "string",
+                    "description": "The output directory where the results will be saved.",
+                    "default": "./results",
+                    "fa_icon": "fas fa-folder-open"
+                },
+                "email": {
+                    "type": "string",
+                    "description": "Email address for completion summary.",
+                    "fa_icon": "fas fa-envelope",
+                    "help_text": "Set this parameter to your e-mail address to get a summary e-mail with details of the run sent to you when the workflow exits. If set in your user config file (`~/.nextflow/config`) then you don't need to specify this on the command line for every run.",
+                    "pattern": "^([a-zA-Z0-9_\\-\\.]+)@([a-zA-Z0-9_\\-\\.]+)\\.([a-zA-Z]{2,5})$"
+                }
+            },
+            "required": [
+                "reads"
+            ]
+        },
+        "adapter_trimming": {
+            "title": "Adapter trimming",
+            "type": "object",
+            "description": "Bisulfite libraries often require additional base pairs to be removed from the ends of the reads before alignment. You can specify these custom trimming parameters as follows:",
+            "default": "",
+            "properties": {
+                "clip_r1": {
+                    "type": "integer",
+                    "description": "Trim the specified number of bases from the 5' end of read 1 (or single-end reads).",
+                    "fa_icon": "fas fa-cut"
+                },
+                "clip_r2": {
+                    "type": "integer",
+                    "description": "Trim the specified number of bases from the 5' end of read 2 (paired-end only).",
+                    "fa_icon": "fas fa-cut"
+                },
+                "three_prime_clip_r1": {
+                    "type": "integer",
+                    "description": "Trim the specified number of bases from the 3' end of read 1 AFTER adapter/quality trimming",
+                    "fa_icon": "fas fa-cut"
+                },
+                "three_prime_clip_r2": {
+                    "type": "integer",
+                    "description": "Trim the specified number of bases from the 3' end of read 2 AFTER adapter/quality trimming",
+                    "fa_icon": "fas fa-cut"
+                },
+                "rrbs": {
+                    "type": "boolean",
+                    "description": "Turn on if dealing with MspI digested material.",
+                    "help_text": "Specifying `--rrbs` will pass on the `--rrbs` parameter to TrimGalore! See the [TrimGalore! documentation](https://github.com/FelixKrueger/TrimGalore/blob/master/Docs/Trim_Galore_User_Guide.md#rrbs-specific-options-mspi-digested-material) to read more about the effects of this option.\n\nThis parameter also makes the pipeline skip the deduplication step.",
+                    "fa_icon": "fas fa-search-plus"
+                },
+                "pbat": {
+                    "type": "boolean",
+                    "help_text": "Specifying `--rrbs` will pass on the `--rrbs` parameter to TrimGalore! See the [TrimGalore! documentation](https://github.com/FelixKrueger/TrimGalore/blob/master/Docs/Trim_Galore_User_Guide.md#rrbs-specific-options-mspi-digested-material) to read more about the effects of this option.\n\nThis parameter also makes the pipeline skip the deduplication step.\n",
+                    "fa_icon": "fas fa-search-plus"
+                },
+                "single_cell": {
+                    "type": "boolean",
+                    "help_text": "Specifying `--single_cell` will pass on the `--single_cell` parameter to TrimGalore!\n\nNote that the `--single_cell` and `--zymo` parameters both set the `--non_directional` workflow flag automatically.\n",
+                    "fa_icon": "fas fa-search-plus"
+                },
+                "epignome": {
+                    "type": "boolean",
+                    "help_text": "Specifying `--epigenome` will pass on the `--epigenome` parameter to TrimGalore!\n",
+                    "fa_icon": "fas fa-search-plus"
+                },
+                "accel": {
+                    "type": "boolean",
+                    "help_text": "Specifying `--accel` will pass on the `--accel` parameter to TrimGalore! ",
+                    "fa_icon": "fas fa-search-plus"
+                },
+                "zymo": {
+                    "type": "boolean",
+                    "help_text": "Specifying `--zymo` will pass on the `--zymo` parameter to TrimGalore! ",
+                    "fa_icon": "fas fa-search-plus"
+                },
+                "cegx": {
+                    "type": "boolean",
+                    "help_text": "Specifying `--cegx` will pass on the `--cegx` parameter to TrimGalore! ",
+                    "fa_icon": "fas fa-search-plus"
+                },
+                "skip_trimming": {
+                    "type": "boolean",
+                    "description": "Skip read trimming.",
+                    "help_text": "Specifying `--skip_trimming` will skip the adapter trimming step. Use this if your input FastQ files have already been trimmed outside of the workflow.\n",
+                    "fa_icon": "fas fa-fast-forward"
+                },
+                "save_trimmed": {
+                    "type": "boolean",
+                    "description": "Save trimmed reads to results directory.",
+                    "help_text": "By default, trimmed FastQ files will not be saved to the results directory. Specify this flag (or set to true in your config file) to copy these files to the results directory when complete.\n",
+                    "fa_icon": "far fa-save"
+                }
+            },
+            "help_text": "The pipeline also accepts a number of presets for common bisulfite library preparation methods:\n\n| Parameter       | 5' R1 Trim | 5' R2 Trim | 3' R1 Trim | 3' R2 Trim |\n|-----------------|------------|------------|------------|------------|\n| `--pbat`        | 6          | 9          | 6          | 9          |\n| `--single_cell` | 6          | 6          | 6          | 6          |\n| `--epignome`    | 8          | 8          | 8          | 8          |\n| `--accel`       | 10         | 15         | 10         | 10         |\n| `--zymo`        | 10         | 15         | 10         | 10         |\n| `--cegx`        | 6          | 6          | 2          | 2          |",
+            "fa_icon": "fas fa-cut"
+        },
+        "reference_genome_options": {
+            "title": "Reference genome options",
+            "type": "object",
+            "fa_icon": "fas fa-dna",
+            "description": "Options for the reference genome indices used to align reads.",
+            "properties": {
+                "genome": {
+                    "type": "string",
+                    "description": "Name of iGenomes reference.",
+                    "fa_icon": "fas fa-book",
+                    "help_text": "If using a reference genome configured in the pipeline using iGenomes, use this parameter to give the ID for the reference. This is then used to build the full paths for all required reference genome files e.g. `--genome GRCh38`.\n\nSee the [nf-core website docs](https://nf-co.re/usage/reference_genomes) for more details."
+                },
+                "fasta": {
+                    "type": "string",
+                    "fa_icon": "fas fa-font",
+                    "description": "Path to FASTA genome file.",
+                    "help_text": "If you have no genome reference available, the pipeline can build one using a FASTA file. This requires additional time and resources, so it's better to use a pre-build index if possible."
+                },
+                "igenomes_base": {
+                    "type": "string",
+                    "description": "Directory / URL base for iGenomes references.",
+                    "default": "s3://ngi-igenomes/igenomes/",
+                    "fa_icon": "fas fa-cloud-download-alt"
+                },
+                "igenomes_ignore": {
+                    "type": "boolean",
+                    "description": "Do not load the iGenomes reference config.",
+                    "fa_icon": "fas fa-ban",
+                    "help_text": "Do not load `igenomes.config` when running the pipeline. You may choose this option if you observe clashes between custom parameters and those supplied in `igenomes.config`."
+                },
+                "fasta_index": {
+                    "type": "string",
+                    "description": "Path to fasta index.",
+                    "fa_icon": "fas fa-bezier-curve"
+                },
+                "bwa_meth_index": {
+                    "type": "string",
+                    "description": "Path to bwameth index.",
+                    "fa_icon": "fas fa-bezier-curve"
+                },
+                "bismark_index": {
+                    "type": "string",
+                    "description": "Path to Bismark index.",
+                    "fa_icon": "fas fa-bezier-curve"
+                }
+            }
+        },
+        "alignment_options": {
+            "title": "Alignment options",
+            "type": "object",
+            "description": "Options to adjust parameters and filtering criteria for read alignments.",
+            "default": "",
+            "properties": {
+                "aligner": {
+                    "type": "string",
+                    "default": "bismark",
+                    "description": "Alignment tool to use.",
+                    "enum": [
+                        "bismark",
+                        "bismark_hisat",
+                        "bwameth"
+                    ],
+                    "help_text": "The nf-core/methylseq package is actually two pipelines in one. The default workflow uses [Bismark](http://www.bioinformatics.babraham.ac.uk/projects/bismark/) with [Bowtie2](http://bowtie-bio.sourceforge.net/bowtie2/index.shtml) as alignment tool: unless specified otherwise, nf-core/methylseq will run this pipeline.\n\nSince bismark v0.21.0 it is also possible to use [HISAT2](https://ccb.jhu.edu/software/hisat2/index.shtml) as alignment tool. To run this workflow, invoke the pipeline with the command line flag `--aligner bismark_hisat`. HISAT2 also supports splice-aware alignment if analysis of RNA is desired (e.g. [SLAMseq](https://science.sciencemag.org/content/360/6390/800) experiments), a file containing a list of known splicesites can be provided with `--known_splices`.\n\nThe second workflow uses [BWA-Meth](https://github.com/brentp/bwa-meth) and [MethylDackel](https://github.com/dpryan79/methyldackel) instead of Bismark. To run this workflow, run the pipeline with the command line flag `--aligner bwameth`.\n",
+                    "fa_icon": "fas fa-map-signs"
+                },
+                "local_alignment": {
+                    "type": "boolean",
+                    "description": "Allow soft-clipping of reads (potentially useful for single-cell experiments).",
+                    "help_text": "Specify to run Bismark with the `--local` flag to allow soft-clipping of reads. This should only be used with care in certain single-cell applications or PBAT libraries, which may produce chimeric read pairs. (See [Wu et al.](https://doi.org/10.1093/bioinformatics/btz125) (doesn't work with `--aligner bwameth`)",
+                    "fa_icon": "fas fa-map-marker-alt"
+                },
+                "skip_deduplication": {
+                    "type": "boolean",
+                    "description": "Skip deduplication step after alignment. This is turned on automatically if `` --rrbs` is specified.",
+                    "help_text": "By default, the pipeline includes a deduplication step after alignment. Use `--skip_deduplication` on the command line to skip this step. This is automatically set if using `--rrbs` for the workflow.\n",
+                    "fa_icon": "fas fa-fast-forward"
+                },
+                "known_splices": {
+                    "type": "string",
+                    "description": "Supply a `.gtf` file containing known splice sites (`bismark_hisat` only).",
+                    "help_text": "Specify to run Bismark with the `--known-splicesite-infile` flag to run splice-aware alignment using HISAT2. A `.gtf` file has to be provided from which a list of known splicesites is created by the pipeline. (only works with `--aligner bismark_hisat`)\n",
+                    "fa_icon": "fas fa-hand-scissors"
+                },
+                "save_align_intermeds": {
+                    "type": "boolean",
+                    "description": "Save aligned intermediates to results directory.",
+                    "help_text": "By default intermediate BAM files will not be saved. The final BAM files created after the deduplication step are always. Set to true to also copy out BAM files from the initial Bismark alignment step. If `--skip_deduplication` or `--rrbs` is specified then BAMs from the initial alignment will always be saved.\n",
+                    "fa_icon": "fas fa-save"
+                },
+                "save_reference": {
+                    "type": "boolean",
+                    "description": "Save reference(s) to results directory.",
+                    "help_text": "If you don't want to use the Illumina iGenomes references, you can supply your own reference genome.\n\nThe minimum requirement is just a FASTA file - the pipeline will automatically generate the relevant reference index from this. You can use the command line option `--save_reference` to keep the generated references so that they can be added to your config and used again in the future. The bwa-meth workflow always needs a FASTA file, for methylation calling.",
+                    "fa_icon": "fas fa-save"
+                },
+                "unmapped": {
+                    "type": "boolean",
+                    "description": "Save unmapped reads to fastq files.",
+                    "help_text": "Use the `--unmapped` flag to set the `--unmapped` flag with Bismark align and save the unmapped reads to FastQ files.\n",
+                    "fa_icon": "fas fa-save"
+                },
+                "relax_mismatches": {
+                    "type": "boolean",
+                    "description": "Turn on to relax stringency for alignment (set allowed penalty with `--num_mismatches`).",
+                    "help_text": "By default, Bismark is pretty strict about which alignments it accepts as valid. If you have good reason to believe that your reads will contain more mismatches than normal, these flags can be used to relax the stringency that Bismark uses when accepting alignments. This can greatly improve the number of aligned reads you get back, but may negatively impact the quality of your data.\n\n`--num_mismatches` is `0.2` by default in Bismark, or `0.6` if `--relax_mismatches` is specified. `0.6` will allow a penalty of `bp * -0.6` - for 100bp reads, this is `-60`. Mismatches cost `-6`, gap opening `-5` and gap extension `-2`. So, `-60` would allow 10 mismatches or ~ 8 x 1-2bp indels.",
+                    "fa_icon": "fas fa-couch"
+                },
+                "num_mismatches": {
+                    "type": "number",
+                    "default": 0.6,
+                    "description": "0.6 will allow a penalty of bp * -0.6 - for 100bp reads (bismark default is 0.2).",
+                    "help_text": "By default, Bismark is pretty strict about which alignments it accepts as valid. If you have good reason to believe that your reads will contain more mismatches than normal, these flags can be used to relax the stringency that Bismark uses when accepting alignments. This can greatly improve the number of aligned reads you get back, but may negatively impact the quality of your data.\n\n`--num_mismatches` is `0.2` by default in Bismark, or `0.6` if `--relax_mismatches` is specified. `0.6` will allow a penalty of `bp * -0.6` - for 100bp reads, this is `-60`. Mismatches cost `-6`, gap opening `-5` and gap extension `-2`. So, `-60` would allow 10 mismatches or ~ 8 x 1-2bp indels.",
+                    "fa_icon": "fas fa-ban"
+                },
+                "non_directional": {
+                    "type": "boolean",
+                    "description": "Run alignment against all four possible strands.",
+                    "help_text": "By default, Bismark assumes that libraries are directional and does not align against complementary strands. If your library prep was not directional, use `--non_directional` to align against all four possible strands.\n\nNote that the `--single_cell` and `--zymo` parameters both set the `--non_directional` workflow flag automatically.",
+                    "fa_icon": "far fa-compass"
+                }
+            },
+            "fa_icon": "fas fa-map-signs"
+        },
+        "additional_parameters": {
+            "title": "Additional parameters",
+            "type": "object",
+            "description": "Related to the methylseq tools (Bismark, BWA-Meth and MethylDackel)",
+            "default": "",
+            "properties": {
+                "min_depth": {
+                    "type": "integer",
+                    "description": "Specify a minimum read coverage for `MethylDackel` to report a methylation call.",
+                    "fa_icon": "fas fa-align-center"
+                },
+                "meth_cutoff": {
+                    "type": "integer",
+                    "description": "Specify a minimum read coverage to report a methylation call during Bismark's `bismark_methylation_extractor` step.",
+                    "fa_icon": "fas fa-align-center"
+                },
+                "cytosine_report": {
+                    "type": "boolean",
+                    "description": "Output stranded cytosine report during Bismark's bismark_methylation_extractor step.",
+                    "help_text": "By default, Bismark does not produce stranded calls. With this option the output considers all Cs on both forward and reverse strands and reports their position, strand, trinucleotide context and methylation state.\n",
+                    "fa_icon": "fab fa-cuttlefish"
+                },
+                "slamseq": {
+                    "type": "boolean",
+                    "description": "Run bismark in SLAM-seq mode.",
+                    "help_text": "Specify to run Bismark with the `--slam` flag to run bismark in [SLAM-seq mode](https://github.com/FelixKrueger/Bismark/blob/master/CHANGELOG.md#slam-seq-mode) (only works with `--aligner bismark_hisat`)\n",
+                    "fa_icon": "fas fa-angle-right"
+                },
+                "ignore_flags": {
+                    "type": "boolean",
+                    "description": "Run `MethylDackel` with the flag to ignore SAM flags.",
+                    "fa_icon": "far fa-flag"
+                },
+                "methyl_kit": {
+                    "type": "boolean",
+                    "description": "Run `MethylDackel` with the `--methyl_kit flag to produce files suitable for use with the methylKit R package.",
+                    "fa_icon": "fas fa-briefcase"
+                },
+                "bismark_align_cpu_per_multicore": {
+                    "type": "integer",
+                    "default": "3",
+                    "description": "Specify how many CPUs are required per `--multicore` for `bismark align`.",
+                    "help_text": "The pipeline makes use of the `--multicore` option for Bismark align. When using this option,\nBismark uses a large number of CPUs for every `--multicore` specified. The pipeline\ncalculates the number of `--multicore` based on the resources available to the task.\nIt divides the available CPUs by 3, or by 5 if any of `--single_cell`, `--zymo` or `--non_directional`\nare specified. This is based on usage for a typical mouse genome.\n\nYou may find when running the pipeline that Bismark is not using this many CPUs. To fine tune the\nusage and speed, you can specify an integer with `--bismark_align_cpu_per_multicore` and the pipeline\nwill divide the available CPUs by this value instead.\n\nSee the [bismark documentation](https://github.com/FelixKrueger/Bismark/tree/master/Docs#alignment)\nfor more information.",
+                    "fa_icon": "fas fa-server"
+                },
+                "bismark_align_mem_per_multicore": {
+                    "type": "string",
+                    "default": "13.GB",
+                    "description": "Specify how much memory is required per `--multicore` for `bismark align`.",
+                    "help_text": "Exactly as above, but for memory. By default, the pipeline divides the available memory by `13.GB`,\nor `18.GB` if any of `--single_cell`, `--zymo` or `--non_directional` are specified.\n\nNote that the final `--multicore` value is based on the lowest limiting factor of both CPUs and memory.",
+                    "fa_icon": "fas fa-server"
+                }
+            },
+            "fa_icon": "fas fa-pen"
+        },
+        "generic_options": {
+            "title": "Generic options",
+            "type": "object",
+            "fa_icon": "fas fa-file-import",
+            "description": "Less common options for the pipeline, typically set in a config file.",
+            "help_text": "These options are common to all nf-core pipelines and allow you to customise some of the core preferences for how the pipeline runs.\n\nTypically these options would be set in a Nextflow config file loaded for all pipeline runs, such as `~/.nextflow/config`.",
+            "properties": {
+                "help": {
+                    "type": "boolean",
+                    "description": "Display help text.",
+                    "hidden": true,
+                    "fa_icon": "fas fa-question-circle"
+                },
+                "email_on_fail": {
+                    "type": "string",
+                    "description": "Email address for completion summary, only when pipeline fails.",
+                    "fa_icon": "fas fa-exclamation-triangle",
+                    "pattern": "^([a-zA-Z0-9_\\-\\.]+)@([a-zA-Z0-9_\\-\\.]+)\\.([a-zA-Z]{2,5})$",
+                    "hidden": true,
+                    "help_text": "This works exactly as with `--email`, except emails are only sent if the workflow is not successful."
+                },
+                "plaintext_email": {
+                    "type": "boolean",
+                    "description": "Send plain-text email instead of HTML.",
+                    "fa_icon": "fas fa-remove-format",
+                    "hidden": true,
+                    "help_text": "Set to receive plain-text e-mails instead of HTML formatted."
+                },
+                "max_multiqc_email_size": {
+                    "type": "string",
+                    "description": "File size limit when attaching MultiQC reports to summary emails.",
+                    "default": "25.MB",
+                    "fa_icon": "fas fa-file-upload",
+                    "hidden": true,
+                    "help_text": "If file generated by pipeline exceeds the threshold, it will not be attached."
+                },
+                "monochrome_logs": {
+                    "type": "boolean",
+                    "description": "Do not use coloured log outputs.",
+                    "fa_icon": "fas fa-palette",
+                    "hidden": true,
+                    "help_text": "Set to disable colourful command line output and live life in monochrome."
+                },
+                "multiqc_config": {
+                    "type": "string",
+                    "description": "Custom config file to supply to MultiQC.",
+                    "fa_icon": "fas fa-cog",
+                    "hidden": true
+                },
+                "tracedir": {
+                    "type": "string",
+                    "description": "Directory to keep pipeline Nextflow logs and reports.",
+                    "default": "${params.outdir}/pipeline_info",
+                    "fa_icon": "fas fa-cogs",
+                    "hidden": true
+                }
+            }
+        },
+        "max_job_request_options": {
+            "title": "Max job request options",
+            "type": "object",
+            "fa_icon": "fab fa-acquisitions-incorporated",
+            "description": "Set the top limit for requested resources for any single job.",
+            "help_text": "If you are running on a smaller system, a pipeline step requesting more resources than are available may cause the Nextflow to stop the run with an error. These options allow you to cap the maximum resources requested by any single job so that the pipeline will run on your system.\n\nNote that you can not _increase_ the resources requested by any job using these options. For that you will need your own configuration file. See [the nf-core website](https://nf-co.re/usage/configuration) for details.",
+            "properties": {
+                "max_cpus": {
+                    "type": "integer",
+                    "description": "Maximum number of CPUs that can be requested    for any single job.",
+                    "default": 16,
+                    "fa_icon": "fas fa-microchip",
+                    "hidden": true,
+                    "help_text": "Use to set an upper-limit for the CPU requirement for each process. Should be an integer e.g. `--max_cpus 1`"
+                },
+                "max_memory": {
+                    "type": "string",
+                    "description": "Maximum amount of memory that can be requested for any single job.",
+                    "default": "128.GB",
+                    "fa_icon": "fas fa-memory",
+                    "pattern": "^[\\d\\.]+\\s*.(K|M|G|T)?B$",
+                    "hidden": true,
+                    "help_text": "Use to set an upper-limit for the memory requirement for each process. Should be a string in the format integer-unit e.g. `--max_memory '8.GB'`"
+                },
+                "max_time": {
+                    "type": "string",
+                    "description": "Maximum amount of time that can be requested for any single job.",
+                    "default": "240.h",
+                    "fa_icon": "far fa-clock",
+                    "pattern": "^[\\d\\.]+\\.*(s|m|h|d)$",
+                    "hidden": true,
+                    "help_text": "Use to set an upper-limit for the time requirement for each process. Should be a string in the format integer-unit e.g. `--max_time '2.h'`"
+                }
+            }
+        },
+        "institutional_config_options": {
+            "title": "Institutional config options",
+            "type": "object",
+            "fa_icon": "fas fa-university",
+            "description": "Parameters used to describe centralised config profiles. These should not be edited.",
+            "help_text": "The centralised nf-core configuration profiles use a handful of pipeline parameters to describe themselves. This information is then printed to the Nextflow log when you run a pipeline. You should not need to change these values when you run a pipeline.",
+            "properties": {
+                "custom_config_version": {
+                    "type": "string",
+                    "description": "Git commit id for Institutional configs.",
+                    "default": "master",
+                    "hidden": true,
+                    "fa_icon": "fas fa-users-cog",
+                    "help_text": "Provide git commit id for custom Institutional configs hosted at `nf-core/configs`. This was implemented for reproducibility purposes. Default: `master`.\n\n```bash\n## Download and use config file with following git commit id\n--custom_config_version d52db660777c4bf36546ddb188ec530c3ada1b96\n```"
+                },
+                "custom_config_base": {
+                    "type": "string",
+                    "description": "Base directory for Institutional configs.",
+                    "default": "https://raw.githubusercontent.com/nf-core/configs/master",
+                    "hidden": true,
+                    "help_text": "If you're running offline, nextflow will not be able to fetch the institutional config files from the internet. If you don't need them, then this is not a problem. If you do need them, you should download the files from the repo and tell nextflow where to find them with the `custom_config_base` option. For example:\n\n```bash\n## Download and unzip the config files\ncd /path/to/my/configs\nwget https://github.com/nf-core/configs/archive/master.zip\nunzip master.zip\n\n## Run the pipeline\ncd /path/to/my/data\nnextflow run /path/to/pipeline/ --custom_config_base /path/to/my/configs/configs-master/\n```\n\n> Note that the nf-core/tools helper package has a `download` command to download all required pipeline files + singularity containers + institutional configs in one go for you, to make this process easier.",
+                    "fa_icon": "fas fa-users-cog"
+                },
+                "hostnames": {
+                    "type": "string",
+                    "description": "Institutional configs hostname.",
+                    "hidden": true,
+                    "fa_icon": "fas fa-users-cog"
+                },
+                "config_profile_description": {
+                    "type": "string",
+                    "description": "Institutional config description.",
+                    "hidden": true,
+                    "fa_icon": "fas fa-users-cog"
+                },
+                "config_profile_contact": {
+                    "type": "string",
+                    "description": "Institutional config contact information.",
+                    "hidden": true,
+                    "fa_icon": "fas fa-users-cog"
+                },
+                "config_profile_url": {
+                    "type": "string",
+                    "description": "Institutional config URL link.",
+                    "hidden": true,
+                    "fa_icon": "fas fa-users-cog"
+                }
+            }
+        }
+    },
+    "allOf": [
+        {
+            "$ref": "#/definitions/input_output_options"
+        },
+        {
+            "$ref": "#/definitions/adapter_trimming"
+        },
+        {
+            "$ref": "#/definitions/reference_genome_options"
+        },
+        {
+            "$ref": "#/definitions/alignment_options"
+        },
+        {
+            "$ref": "#/definitions/additional_parameters"
+        },
+        {
+            "$ref": "#/definitions/generic_options"
+        },
+        {
+            "$ref": "#/definitions/max_job_request_options"
+        },
+        {
+            "$ref": "#/definitions/institutional_config_options"
+        }
+    ],
+    "properties": {
+        "clusterOptions": {
+            "type": "string",
+            "description": "Arguments passed to Nextflow clusterOptions.",
+            "hidden": true,
+            "help_text": "UPPMAX profile only: Submit arbitrary SLURM options.",
+            "fa_icon": "fas fa-network-wired"
+        }
+    }
+}


### PR DESCRIPTION
# nf-core/methylseq pull request

Methylseq: Convert parameter docs to JSON schema. Based on the following issue: https://github.com/nf-core/methylseq/issues/189. 

Added first nextflow_schema.json file for methylseq. 

