### PR TITLE
Bump Dockerfile to nf-core 1.13.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nfcore/base:1.13.2
+FROM nfcore/base:1.13.3
 LABEL authors="Phil Ewels" \
       description="Docker image containing all software requirements for the nf-core/methylseq pipeline"
 


### PR DESCRIPTION
Bumping the nf-core version in the `Dockerfile` after the latest release, to get the `nf-core lint` tests working.