### PR TITLE
Remove default from schema which does not match the config

### DIFF
--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -278,7 +278,6 @@
                 "meth_cutoff": {
                     "type": "integer",
                     "description": "Specify a minimum read coverage to report a methylation call",
-                    "default": 0,
                     "help_text": "Use to discard any methylation calls with less than a given read coverage depth (in fold coverage) during Bismark's `bismark_methylation_extractor` step.",
                     "fa_icon": "fas fa-angle-double-down"
                 },


### PR DESCRIPTION
Minor tweak to the schema - removed a default value where none was needed, and it was not matching `nextflow.config`.

Prevents this parameter from being highlighted as an input when running the pipeline (with a fixed summary log).



## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
  - [ ] If you've added a new tool - add to the software_versions process and a regex to `scrape_software_versions.py`
  - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/methylseq/tree/master/.github/CONTRIBUTING.md)
  - [ ] If necessary, also make a PR on the nf-core/methylseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint .`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
