### PR TITLE
Prepare 1.6.1 release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,13 +42,13 @@ jobs:
 
       - name: Build new docker image
         if: env.MATCHED_FILES
-        run: docker build --no-cache . -t nfcore/methylseq:dev
+        run: docker build --no-cache . -t nfcore/methylseq:1.6.1
 
       - name: Pull docker image
         if: ${{ !env.MATCHED_FILES }}
         run: |
           docker pull nfcore/methylseq:dev
-          docker tag nfcore/methylseq:dev nfcore/methylseq:dev
+          docker tag nfcore/methylseq:dev nfcore/methylseq:1.6.1
 
       - name: Install Nextflow
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # nf-core/methylseq
 
-## v1.7dev
+## [v1.6.1](https://github.com/nf-core/methylseq/releases/tag/1.6.1) - 2021-05-08
 
 ### Pipeline Updates
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY environment.yml /
 RUN conda env create --quiet -f /environment.yml && conda clean -a
 
 # Add conda installation dir to PATH (instead of doing 'conda activate')
-ENV PATH /opt/conda/envs/nf-core-methylseq-1.7dev/bin:$PATH
+ENV PATH /opt/conda/envs/nf-core-methylseq-1.6.1/bin:$PATH
 
 # Dump the details of the installed packages to a file for posterity
-RUN conda env export --name nf-core-methylseq-1.7dev > nf-core-methylseq-1.7dev.yml
+RUN conda env export --name nf-core-methylseq-1.6.1 > nf-core-methylseq-1.6.1.yml

--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,6 @@
 # You can use this file to create a conda environment for this pipeline:
 #   conda env create -f environment.yml
-name: nf-core-methylseq-1.7dev
+name: nf-core-methylseq-1.6.1
 channels:
   - conda-forge
   - bioconda

--- a/nextflow.config
+++ b/nextflow.config
@@ -86,7 +86,7 @@ params {
 
 // Container slug. Stable releases should specify release tag!
 // Developmental code should specify :dev
-process.container = 'nfcore/methylseq:dev'
+process.container = 'nfcore/methylseq:1.6.1'
 
 // Load base.config by default for all pipelines
 includeConfig 'conf/base.config'
@@ -193,7 +193,7 @@ manifest {
   description = 'Methylation (Bisulfite-Sequencing) Best Practice analysis pipeline, part of the nf-core community.'
   mainScript = 'main.nf'
   nextflowVersion = '>=20.07.1'
-  version = '1.7dev'
+  version = '1.6.1'
 }
 
 // Function to ensure that resource requirements don't go beyond


### PR DESCRIPTION
I think that the bismark bug / bugfix was serious enough to warrant a minor release (even though it had no effect). This PR prepares for a 1.6.1 version.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] `CHANGELOG.md` is updated.
