### PR TITLE
bwameth align - touch files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## 1.7dev
 
-_..nothing yet.._
+### Bug fixes
+
+* Run `touch` before bwa alignments to modify file modified timestamps. Avoids error from bwa about needing to build the index ([#217](https://github.com/nf-core/methylseq/issues/217))
 
 ## [v1.6.1](https://github.com/nf-core/methylseq/releases/tag/1.6.1) - 2021-05-08
 

--- a/main.nf
+++ b/main.nf
@@ -740,6 +740,8 @@ if( params.aligner == 'bwameth' ){
         fasta = bwa_meth_indices[0].toString() - '.bwameth' - '.c2t' - '.amb' - '.ann' - '.bwt' - '.pac' - '.sa'
         prefix = reads[0].toString() - ~/(_R1)?(_trimmed)?(_val_1)?(\.fq)?(\.fastq)?(\.gz)?$/
         """
+        # Modify the timestamps so that bwameth doesn't complain about building the index
+        touch -c -- *
         bwameth.py \\
             --threads ${task.cpus} \\
             --reference $fasta \\


### PR DESCRIPTION
bwameth align - touch files to avoid index build error. See for example: https://github.com/nf-core/methylseq/runs/2564102125?check_suite_focus=true

```python
  Traceback (most recent call last):
    File "/opt/conda/envs/nf-core-methylseq-1.7dev/bin/bwameth.py", line 509, in <module>
      main(sys.argv[1:])
    File "/opt/conda/envs/nf-core-methylseq-1.7dev/bin/bwameth.py", line 502, in main
      bwa_mem(args.reference, conv_fqs_cmd, ' '.join(map(str, pass_through_args)),
    File "/opt/conda/envs/nf-core-methylseq-1.7dev/bin/bwameth.py", line 315, in bwa_mem
      raise BWAMethException("first run bwameth.py index %s" % fa)
  __main__.BWAMethException: first run bwameth.py index genome.fa
  [main_samview] fail to read the header from "-".
```

Discovered by @Shabhonam and reported [on the nf-core Slack](https://nfcore.slack.com/archives/CP3RJSMF0/p1624002989043500).

> Looking at the bwameth.py source, it seems this is due to a check whether one file is newer than another: https://github.com/brentp/bwa-meth/blob/master/bwameth.py#L315

This PR incorporates his fix into the pipeline - adding a `touch` command to update the modified timestamps on the reference files before running.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
  - [ ] If you've added a new tool - add to the software_versions process and a regex to `scrape_software_versions.py`
  - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/methylseq/tree/master/.github/CONTRIBUTING.md)
  - [ ] If necessary, also make a PR on the nf-core/methylseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint .`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
