### PR TITLE
Add coverage2cytosine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,12 @@
 
 ### Pipeline Updates
 
+- ✨ Added option to run the Bismark `coverage2cytosine` script using the `--coverage2cytosine` and `--nomeseq` parameters.
 - 🐛 Fixed bad bug where trimming presets were not being applied ([#261](https://github.com/nf-core/methylseq/pull/261))
 
 ### Software Updates
+
+- Update Bismark v0.23.0 to v0.24.0
 
 ## [v2.0.0](https://github.com/nf-core/methylseq/releases/tag/2.0) - 2022-11-09
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -145,12 +145,13 @@ process {
 
     withName: BISMARK_METHYLATIONEXTRACTOR {
         ext.args   = { [
-                        params.comprehensive   ? ' --comprehensive --merge_non_CpG' : '',
-                        params.cytosine_report ? ' --cytosine_report --genome_folder BismarkIndex' : '',
-                        params.meth_cutoff     ? " --cutoff ${params.meth_cutoff}" : '',
+                        params.comprehensive     ? ' --comprehensive --merge_non_CpG' : '',
+                        params.cytosine_report   ? ' --cytosine_report --genome_folder BismarkIndex' : '',
+                        params.meth_cutoff       ? " --cutoff ${params.meth_cutoff}" : '',
+                        (params.coverage2cytosine && params.nomeseq) ? '--CX' : '',
                         meta.single_end ? '' : (params.no_overlap           ? ' --no_overlap'                         : '--include_overlap'),
                         meta.single_end ? '' : (params.ignore_r2        > 0 ? "--ignore_r2 ${params.ignore_r2}"       : ""),
-                        meta.single_end ? '' : (params.ignore_3prime_r2 > 0 ? "--ignore_r2 ${params.ignore_3prime_r2}": "")
+                        meta.single_end ? '' : (params.ignore_3prime_r2 > 0 ? "--ignore_r2 ${params.ignore_3prime_r2}": ""),
                     ].join(' ').trim() }
         publishDir = [
             [
@@ -182,6 +183,27 @@ process {
                 path: { "${params.outdir}/${params.aligner}/methylation_calls/methylation_calls" },
                 mode: params.publish_dir_mode,
                 pattern: "*txt.gz"
+            ]
+        ]
+    }
+
+    withName: BISMARK_COVERAGE2CYTOSINE {
+        ext.args = params.nomeseq ? '--nome-seq' : ''
+        publishDir = [
+            [
+                path: { "${params.outdir}/bismark/coverage2cytosine/coverage" },
+                mode: params.publish_dir_mode,
+                pattern: "*.cov.gz"
+            ],
+            publishDir = [
+                path: { "${params.outdir}/bismark/coverage2cytosine/summaries" },
+                mode: params.publish_dir_mode,
+                pattern: "*_summary.txt"
+            ],
+            publishDir = [
+                path: { "${params.outdir}/bismark/coverage2cytosine/reports" },
+                mode: params.publish_dir_mode,
+                pattern: "*_report.txt.gz"
             ]
         ]
     }

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -145,10 +145,10 @@ process {
 
     withName: BISMARK_METHYLATIONEXTRACTOR {
         ext.args   = { [
-                        params.comprehensive     ? ' --comprehensive --merge_non_CpG' : '',
-                        params.cytosine_report   ? ' --cytosine_report --genome_folder BismarkIndex' : '',
-                        params.meth_cutoff       ? " --cutoff ${params.meth_cutoff}" : '',
-                        (params.coverage2cytosine && params.nomeseq) ? '--CX' : '',
+                        params.comprehensive   ? ' --comprehensive --merge_non_CpG' : '',
+                        params.cytosine_report ? ' --cytosine_report --genome_folder BismarkIndex' : '',
+                        params.meth_cutoff     ? " --cutoff ${params.meth_cutoff}" : '',
+                        params.nomeseq         ? '--CX' : '',
                         meta.single_end ? '' : (params.no_overlap           ? ' --no_overlap'                         : '--include_overlap'),
                         meta.single_end ? '' : (params.ignore_r2        > 0 ? "--ignore_r2 ${params.ignore_r2}"       : ""),
                         meta.single_end ? '' : (params.ignore_3prime_r2 > 0 ? "--ignore_r2 ${params.ignore_3prime_r2}": ""),

--- a/modules.json
+++ b/modules.json
@@ -7,7 +7,7 @@
                 "nf-core": {
                     "bismark/align": {
                         "branch": "master",
-                        "git_sha": "a7e1292e0a9600c93a4c9b5b0c191aaf0c17ed00"
+                        "git_sha": "cdaaf00a580a2b3378926b08dd44db1de44ed7b5"
                     },
                     "bismark/coverage2cytosine": {
                         "branch": "master",
@@ -15,31 +15,31 @@
                     },
                     "bismark/deduplicate": {
                         "branch": "master",
-                        "git_sha": "5e34754d42cd2d5d248ca8673c0a53cdf5624905"
+                        "git_sha": "cdaaf00a580a2b3378926b08dd44db1de44ed7b5"
                     },
                     "bismark/genomepreparation": {
                         "branch": "master",
-                        "git_sha": "5e34754d42cd2d5d248ca8673c0a53cdf5624905"
+                        "git_sha": "cdaaf00a580a2b3378926b08dd44db1de44ed7b5"
                     },
                     "bismark/methylationextractor": {
                         "branch": "master",
-                        "git_sha": "a7e1292e0a9600c93a4c9b5b0c191aaf0c17ed00"
+                        "git_sha": "cdaaf00a580a2b3378926b08dd44db1de44ed7b5"
                     },
                     "bismark/report": {
                         "branch": "master",
-                        "git_sha": "5e34754d42cd2d5d248ca8673c0a53cdf5624905"
+                        "git_sha": "cdaaf00a580a2b3378926b08dd44db1de44ed7b5"
                     },
                     "bismark/summary": {
                         "branch": "master",
-                        "git_sha": "5e34754d42cd2d5d248ca8673c0a53cdf5624905"
+                        "git_sha": "cdaaf00a580a2b3378926b08dd44db1de44ed7b5"
                     },
                     "bwameth/align": {
                         "branch": "master",
-                        "git_sha": "5e34754d42cd2d5d248ca8673c0a53cdf5624905"
+                        "git_sha": "cdaaf00a580a2b3378926b08dd44db1de44ed7b5"
                     },
                     "bwameth/index": {
                         "branch": "master",
-                        "git_sha": "5e34754d42cd2d5d248ca8673c0a53cdf5624905"
+                        "git_sha": "cdaaf00a580a2b3378926b08dd44db1de44ed7b5"
                     },
                     "custom/dumpsoftwareversions": {
                         "branch": "master",
@@ -51,11 +51,11 @@
                     },
                     "methyldackel/extract": {
                         "branch": "master",
-                        "git_sha": "6a041ec7dba0b65b23d267b602301dc963610266"
+                        "git_sha": "cdaaf00a580a2b3378926b08dd44db1de44ed7b5"
                     },
                     "methyldackel/mbias": {
                         "branch": "master",
-                        "git_sha": "5e34754d42cd2d5d248ca8673c0a53cdf5624905"
+                        "git_sha": "cdaaf00a580a2b3378926b08dd44db1de44ed7b5"
                     },
                     "multiqc": {
                         "branch": "master",

--- a/modules.json
+++ b/modules.json
@@ -9,6 +9,10 @@
                         "branch": "master",
                         "git_sha": "a7e1292e0a9600c93a4c9b5b0c191aaf0c17ed00"
                     },
+                    "bismark/coverage2cytosine": {
+                        "branch": "master",
+                        "git_sha": "cdaaf00a580a2b3378926b08dd44db1de44ed7b5"
+                    },
                     "bismark/deduplicate": {
                         "branch": "master",
                         "git_sha": "5e34754d42cd2d5d248ca8673c0a53cdf5624905"

--- a/modules/nf-core/bismark/align/main.nf
+++ b/modules/nf-core/bismark/align/main.nf
@@ -2,10 +2,10 @@ process BISMARK_ALIGN {
     tag "$meta.id"
     label 'process_high'
 
-    conda (params.enable_conda ? "bioconda::bismark=0.23.0" : null)
+    conda (params.enable_conda ? "bioconda::bismark=0.24.0" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/bismark:0.23.0--0' :
-        'quay.io/biocontainers/bismark:0.23.0--0' }"
+        'https://depot.galaxyproject.org/singularity/bismark:0.24.0--hdfd78af_0' :
+        'quay.io/biocontainers/bismark:0.24.0--hdfd78af_0' }"
 
     input:
     tuple val(meta), path(reads)

--- a/modules/nf-core/bismark/align/meta.yml
+++ b/modules/nf-core/bismark/align/meta.yml
@@ -8,6 +8,7 @@ keywords:
   - 5mC
   - methylseq
   - bisulphite
+  - bisulfite
   - bam
 tools:
   - bismark:

--- a/modules/nf-core/bismark/coverage2cytosine/main.nf
+++ b/modules/nf-core/bismark/coverage2cytosine/main.nf
@@ -1,0 +1,40 @@
+process BISMARK_COVERAGE2CYTOSINE {
+    tag "$meta.id"
+    label 'process_low'
+
+    conda (params.enable_conda ? "bioconda::bismark=0.23.0" : null)
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/bismark:0.24.0--hdfd78af_0' :
+        'quay.io/biocontainers/bismark:0.24.0--hdfd78af_0' }"
+
+    input:
+    tuple val(meta), path(coverage_file)
+    path index
+
+    output:
+    tuple val(meta), path("*.cov.gz"), optional: true      , emit: coverage
+    tuple val(meta), path("*report.txt.gz")                , emit: report
+    tuple val(meta), path("*cytosine_context_summary.txt") , emit: summary
+    path  "versions.yml"                                   , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+
+    """
+    coverage2cytosine \\
+        $coverage_file \\
+        --genome $index \\
+        --output ${prefix} \\
+        --gzip \\
+        $args
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        bismark: \$(echo \$(bismark -v 2>&1) | sed 's/^.*Bismark Version: v//; s/Copyright.*\$//')
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/bismark/coverage2cytosine/meta.yml
+++ b/modules/nf-core/bismark/coverage2cytosine/meta.yml
@@ -1,0 +1,63 @@
+name: "bismark_coverage2cytosine"
+description: Relates methylation calls back to genomic cytosine contexts.
+keywords:
+  - bismark
+  - consensus
+  - map
+  - methylation
+  - 5mC
+  - methylseq
+  - bisulphite
+  - bisulfite
+  - bam
+  - bedGraph
+tools:
+  - bismark:
+      description: |
+        Bismark is a tool to map bisulfite treated sequencing reads
+        and perform methylation calling in a quick and easy-to-use fashion.
+      homepage: https://github.com/FelixKrueger/Bismark
+      documentation: https://github.com/FelixKrueger/Bismark/tree/master/Docs
+      doi: 10.1093/bioinformatics/btr167
+      licence: ["GPL-3.0-or-later"]
+
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - coverage_file:
+      type: file
+      description: |
+        A file containing methylation calls per position, in the format produced by bismark_methylation_extractor.
+  - index:
+      type: dir
+      description: Bismark genome index directory
+      pattern: "BismarkIndex"
+
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - coverage:
+      type: file
+      description: A file containing methylation calls per position.
+      pattern: "*.cov.gz"
+  - report:
+      type: file
+      description: Genomic cytosine context results.
+      pattern: "*report.txt.gz"
+  - summary:
+      type: file
+      description: Cyotosine context summary report.
+      pattern: "*cytosine_context_summary.txt"
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+
+authors:
+  - "@ewels"

--- a/modules/nf-core/bismark/deduplicate/main.nf
+++ b/modules/nf-core/bismark/deduplicate/main.nf
@@ -2,10 +2,10 @@ process BISMARK_DEDUPLICATE {
     tag "$meta.id"
     label 'process_high'
 
-    conda (params.enable_conda ? "bioconda::bismark=0.23.0" : null)
+    conda (params.enable_conda ? "bioconda::bismark=0.24.0" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/bismark:0.23.0--0' :
-        'quay.io/biocontainers/bismark:0.23.0--0' }"
+        'https://depot.galaxyproject.org/singularity/bismark:0.24.0--hdfd78af_0' :
+        'quay.io/biocontainers/bismark:0.24.0--hdfd78af_0' }"
 
     input:
     tuple val(meta), path(bam)

--- a/modules/nf-core/bismark/deduplicate/meta.yml
+++ b/modules/nf-core/bismark/deduplicate/meta.yml
@@ -10,6 +10,7 @@ keywords:
   - 5mC
   - methylseq
   - bisulphite
+  - bisulfite
   - bam
 tools:
   - bismark:

--- a/modules/nf-core/bismark/genomepreparation/main.nf
+++ b/modules/nf-core/bismark/genomepreparation/main.nf
@@ -2,10 +2,10 @@ process BISMARK_GENOMEPREPARATION {
     tag "$fasta"
     label 'process_high'
 
-    conda (params.enable_conda ? "bioconda::bismark=0.23.0" : null)
+    conda (params.enable_conda ? "bioconda::bismark=0.24.0" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/bismark:0.23.0--0' :
-        'quay.io/biocontainers/bismark:0.23.0--0' }"
+        'https://depot.galaxyproject.org/singularity/bismark:0.24.0--hdfd78af_0' :
+        'quay.io/biocontainers/bismark:0.24.0--hdfd78af_0' }"
 
     input:
     path fasta, stageAs: "BismarkIndex/*"

--- a/modules/nf-core/bismark/genomepreparation/meta.yml
+++ b/modules/nf-core/bismark/genomepreparation/meta.yml
@@ -10,6 +10,7 @@ keywords:
   - 5mC
   - methylseq
   - bisulphite
+  - bisulfite
   - fasta
 tools:
   - bismark:

--- a/modules/nf-core/bismark/methylationextractor/main.nf
+++ b/modules/nf-core/bismark/methylationextractor/main.nf
@@ -2,10 +2,10 @@ process BISMARK_METHYLATIONEXTRACTOR {
     tag "$meta.id"
     label 'process_high'
 
-    conda (params.enable_conda ? "bioconda::bismark=0.23.0" : null)
+    conda (params.enable_conda ? "bioconda::bismark=0.24.0" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/bismark:0.23.0--0' :
-        'quay.io/biocontainers/bismark:0.23.0--0' }"
+        'https://depot.galaxyproject.org/singularity/bismark:0.24.0--hdfd78af_0' :
+        'quay.io/biocontainers/bismark:0.24.0--hdfd78af_0' }"
 
     input:
     tuple val(meta), path(bam)

--- a/modules/nf-core/bismark/methylationextractor/meta.yml
+++ b/modules/nf-core/bismark/methylationextractor/meta.yml
@@ -8,6 +8,7 @@ keywords:
   - 5mC
   - methylseq
   - bisulphite
+  - bisulfite
   - bam
   - bedGraph
 tools:

--- a/modules/nf-core/bismark/report/main.nf
+++ b/modules/nf-core/bismark/report/main.nf
@@ -2,10 +2,10 @@ process BISMARK_REPORT {
     tag "$meta.id"
     label 'process_low'
 
-    conda (params.enable_conda ? "bioconda::bismark=0.23.0" : null)
+    conda (params.enable_conda ? "bioconda::bismark=0.24.0" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/bismark:0.23.0--0' :
-        'quay.io/biocontainers/bismark:0.23.0--0' }"
+        'https://depot.galaxyproject.org/singularity/bismark:0.24.0--hdfd78af_0' :
+        'quay.io/biocontainers/bismark:0.24.0--hdfd78af_0' }"
 
     input:
     tuple val(meta), path(align_report), path(dedup_report), path(splitting_report), path(mbias)

--- a/modules/nf-core/bismark/report/meta.yml
+++ b/modules/nf-core/bismark/report/meta.yml
@@ -7,6 +7,7 @@ keywords:
   - 5mC
   - methylseq
   - bisulphite
+  - bisulfite
   - report
 tools:
   - bismark:

--- a/modules/nf-core/bismark/summary/main.nf
+++ b/modules/nf-core/bismark/summary/main.nf
@@ -1,10 +1,10 @@
 process BISMARK_SUMMARY {
     label 'process_low'
 
-    conda (params.enable_conda ? "bioconda::bismark=0.23.0" : null)
+    conda (params.enable_conda ? "bioconda::bismark=0.24.0" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/bismark:0.23.0--0' :
-        'quay.io/biocontainers/bismark:0.23.0--0' }"
+        'https://depot.galaxyproject.org/singularity/bismark:0.24.0--hdfd78af_0' :
+        'quay.io/biocontainers/bismark:0.24.0--hdfd78af_0' }"
 
     input:
     path(bam)

--- a/modules/nf-core/bismark/summary/meta.yml
+++ b/modules/nf-core/bismark/summary/meta.yml
@@ -9,6 +9,7 @@ keywords:
   - 5mC
   - methylseq
   - bisulphite
+  - bisulfite
   - report
   - summary
 tools:

--- a/modules/nf-core/bwameth/align/meta.yml
+++ b/modules/nf-core/bwameth/align/meta.yml
@@ -9,6 +9,7 @@ keywords:
   - 5mC
   - methylseq
   - bisulphite
+  - bisulfite
   - fastq
   - bam
 tools:

--- a/modules/nf-core/bwameth/index/meta.yml
+++ b/modules/nf-core/bwameth/index/meta.yml
@@ -6,6 +6,7 @@ keywords:
   - index
   - methylseq
   - bisulphite
+  - bisulfite
   - fasta
 tools:
   - bwameth:

--- a/modules/nf-core/methyldackel/extract/meta.yml
+++ b/modules/nf-core/methyldackel/extract/meta.yml
@@ -5,6 +5,7 @@ keywords:
   - 5mC
   - methylseq
   - bisulphite
+  - bisulfite
   - consensus
   - bedGraph
   - bam

--- a/modules/nf-core/methyldackel/mbias/meta.yml
+++ b/modules/nf-core/methyldackel/mbias/meta.yml
@@ -5,6 +5,7 @@ keywords:
   - 5mC
   - methylseq
   - bisulphite
+  - bisulfite
   - methylation bias
   - mbias
   - qc

--- a/nextflow.config
+++ b/nextflow.config
@@ -71,6 +71,8 @@ params {
     maxins                     = null
     bismark_align_cpu_per_multicore = null
     bismark_align_mem_per_multicore = null
+    coverage2cytosine          = false
+    nomeseq                    = false
 
     // bwa-meth options
     min_depth                  = 0

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -71,7 +71,8 @@
                     "fa_icon": "fas fa-cut",
                     "help_text": "By default, trimmed FastQ files will not be saved to the results directory. Specify this flag (or set to true in your config file) to copy these files to the results directory when complete."
                 }
-            }
+            },
+            "fa_icon": "fas fa-save"
         },
         "reference_genome_options": {
             "title": "Reference genome options",
@@ -297,19 +298,22 @@
                     "type": "boolean",
                     "default": true,
                     "description": "Ignore read 2 methylation when it overlaps read 1",
-                    "help_text": "For paired-end reads it is theoretically possible that read_1 and read_2 overlap. To avoid scoring overlapping methylation calls twice, this is set to `true` by default. (Only methylation calls of read 1 are used since read 1 has historically higher quality basecalls than read 2). Whilst this option removes a bias towards more methylation calls in the center of sequenced fragments it may de facto remove a sizable proportion of the data. To count methylation data from both reads in overlapping regions, set this to `false`. "
+                    "help_text": "For paired-end reads it is theoretically possible that read_1 and read_2 overlap. To avoid scoring overlapping methylation calls twice, this is set to `true` by default. (Only methylation calls of read 1 are used since read 1 has historically higher quality basecalls than read 2). Whilst this option removes a bias towards more methylation calls in the center of sequenced fragments it may de facto remove a sizable proportion of the data. To count methylation data from both reads in overlapping regions, set this to `false`. ",
+                    "fa_icon": "fas fa-allergies"
                 },
                 "ignore_r2": {
                     "type": "integer",
                     "default": 2,
                     "description": "Ignore methylation in first n bases of 5' end of R2",
-                    "help_text": "Ignore the first <int> bp from the 5' end of Read 2 of paired-end sequencing results only. Since the first couple of bases in Read 2 of BS-Seq experiments show a severe bias towards non-methylation as a result of end-repairing sonicated fragments with unmethylated cytosines (see M-bias plot), it is recommended that the first couple of bp of Read 2 are removed before starting downstream analysis. Please see the section on M-bias plots in the Bismark User Guide for more details."
+                    "help_text": "Ignore the first <int> bp from the 5' end of Read 2 of paired-end sequencing results only. Since the first couple of bases in Read 2 of BS-Seq experiments show a severe bias towards non-methylation as a result of end-repairing sonicated fragments with unmethylated cytosines (see M-bias plot), it is recommended that the first couple of bp of Read 2 are removed before starting downstream analysis. Please see the section on M-bias plots in the Bismark User Guide for more details.",
+                    "fa_icon": "far fa-eye-slash"
                 },
                 "ignore_3prime_r2": {
                     "type": "integer",
                     "default": 2,
                     "description": "Ignore methylation in last n bases of 3' end of R2",
-                    "help_text": "Ignore the last <int> bp from the 3' end of Read 1 (or single-end alignment files) when processing the methylation call string. This can remove unwanted biases from the end of reads."
+                    "help_text": "Ignore the last <int> bp from the 3' end of Read 1 (or single-end alignment files) when processing the methylation call string. This can remove unwanted biases from the end of reads.",
+                    "fa_icon": "far fa-eye-slash"
                 },
                 "known_splices": {
                     "type": "string",
@@ -334,6 +338,17 @@
                     "fa_icon": "fas fa-expand-alt",
                     "description": "The maximum insert size for valid paired-end alignments.",
                     "help_text": "For example, if `--maxins 100` is specified and a paired-end alignment consists of two 20-bp alignments in the proper orientation with a 60-bp gap between them, that alignment is considered valid (as long as `--minins` is also satisfied). A 61-bp gap would not be valid in that case.\n\nDefault: not specified. Bismark default: `500`."
+                },
+                "coverage2cytosine": {
+                    "type": "boolean",
+                    "fa_icon": "fas fa-align-center",
+                    "description": "Run bismark coverage2cytosine."
+                },
+                "nomeseq": {
+                    "type": "boolean",
+                    "fa_icon": "fas fa-dna",
+                    "description": "Sample is NOMe-seq or NMT-seq. Runs coverage2cytosine.",
+                    "help_text": "Sets `--CX` during methylation extraction and `--nome` during the `coverage2cytosine` step.\n\nWill also force the coverage2cytosine step to run."
                 },
                 "bismark_align_cpu_per_multicore": {
                     "type": "integer",

--- a/subworkflows/local/bismark.nf
+++ b/subworkflows/local/bismark.nf
@@ -3,10 +3,11 @@
  */
 include { BISMARK_GENOMEPREPARATION                   } from '../../modules/nf-core/bismark/genomepreparation/main'
 include { BISMARK_ALIGN                               } from '../../modules/nf-core/bismark/align/main'
-include { BISMARK_METHYLATIONEXTRACTOR                } from '../../modules/nf-core/bismark/methylationextractor/main'
 include { SAMTOOLS_SORT as SAMTOOLS_SORT_ALIGNED      } from '../../modules/nf-core/samtools/sort/main'
 include { SAMTOOLS_SORT as SAMTOOLS_SORT_DEDUPLICATED } from '../../modules/nf-core/samtools/sort/main'
 include { BISMARK_DEDUPLICATE                         } from '../../modules/nf-core/bismark/deduplicate/main'
+include { BISMARK_METHYLATIONEXTRACTOR                } from '../../modules/nf-core/bismark/methylationextractor/main'
+include { BISMARK_COVERAGE2CYTOSINE                   } from '../../modules/nf-core/bismark/coverage2cytosine/main'
 include { BISMARK_REPORT                              } from '../../modules/nf-core/bismark/report/main'
 include { BISMARK_SUMMARY                             } from '../../modules/nf-core/bismark/summary/main'
 
@@ -67,6 +68,18 @@ workflow BISMARK {
         bismark_index
     )
     versions = versions.mix(BISMARK_METHYLATIONEXTRACTOR.out.versions)
+
+
+    /*
+     * Run coverage2cytosine
+     */
+    if (params.coverage2cytosine) {
+        BISMARK_COVERAGE2CYTOSINE (
+            BISMARK_METHYLATIONEXTRACTOR.out.coverage,
+            bismark_index
+        )
+        versions = versions.mix(BISMARK_COVERAGE2CYTOSINE.out.versions)
+    }
 
     /*
      * Generate bismark sample reports

--- a/subworkflows/local/bismark.nf
+++ b/subworkflows/local/bismark.nf
@@ -73,7 +73,7 @@ workflow BISMARK {
     /*
      * Run coverage2cytosine
      */
-    if (params.coverage2cytosine) {
+    if (params.coverage2cytosine || params.nomeseq) {
         BISMARK_COVERAGE2CYTOSINE (
             BISMARK_METHYLATIONEXTRACTOR.out.coverage,
             bismark_index

--- a/tests/bismark/main.nf.test
+++ b/tests/bismark/main.nf.test
@@ -93,7 +93,7 @@ nextflow_pipeline {
 
         then {
             assert workflow.success
-            assert workflow.trace.tasks().size() == 30
+            assert workflow.trace.tasks().size() == 38
         }
     }
 

--- a/tests/bismark/main.nf.test
+++ b/tests/bismark/main.nf.test
@@ -82,4 +82,19 @@ nextflow_pipeline {
         }
     }
 
+    test("Single End NOMe-seq") {
+        when {
+            params {
+                aligner = "bismark"
+                nomeseq = true
+                outdir = "$outputDir"
+            }
+        }
+
+        then {
+            assert workflow.success
+            assert workflow.trace.tasks().size() == 30
+        }
+    }
+
 }

--- a/tests/bismark/main.nf.test
+++ b/tests/bismark/main.nf.test
@@ -21,7 +21,7 @@ nextflow_pipeline {
             assert new File("$outputDir/bismark/methylation_calls/splitting_report/SRR389222_sub1_trimmed_bismark_bt2.deduplicated_splitting_report.txt").exists()
             assert new File("$outputDir/bismark/methylation_calls/splitting_report/SRR389222_sub2_trimmed_bismark_bt2.deduplicated_splitting_report.txt").exists()
             assert new File("$outputDir/bismark/methylation_calls/splitting_report/SRR389222_sub3_trimmed_bismark_bt2.deduplicated_splitting_report.txt").exists()
-            assert path("$outputDir/bismark/methylation_calls/splitting_report/SRR389222_sub3_trimmed_bismark_bt2.deduplicated_splitting_report.txt").md5 == "cfd86032a2c4c913d90e155e87120a54"
+            assert path("$outputDir/bismark/methylation_calls/splitting_report/SRR389222_sub3_trimmed_bismark_bt2.deduplicated_splitting_report.txt").md5 == "13883f84bb3b1cec4593541749571c12"
         }
     }
 


### PR DESCRIPTION
Adds `--coverage2cytosine` and `--nomeseq`.

Uses new bismark/coverage2cytosine module from https://github.com/nf-core/modules/pull/2485

Also pulled in new module updates, meaning Bismark version bump from v0.23 to v0.24

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/methylseq/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/methylseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
