### PR TITLE
Update bismark/summary module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Pipeline Updates
 
+- ✨ Updated the `bismark2summary` step so that it no longer stages the aligned BAM files into the working directory. Should be much faster / cheaper for running on the cloud ([#268](https://github.com/nf-core/methylseq/pull/268))
+
 ### Software Updates
 
 ## [v2.1.0](https://github.com/nf-core/methylseq/releases/tag/2.1.0) - 2022-11-10

--- a/modules.json
+++ b/modules.json
@@ -31,7 +31,7 @@
                     },
                     "bismark/summary": {
                         "branch": "master",
-                        "git_sha": "cdaaf00a580a2b3378926b08dd44db1de44ed7b5"
+                        "git_sha": "e84cc8f07607ad7970db9b6cf79b815b78d9cacd"
                     },
                     "bwameth/align": {
                         "branch": "master",

--- a/modules/nf-core/bismark/summary/main.nf
+++ b/modules/nf-core/bismark/summary/main.nf
@@ -7,7 +7,7 @@ process BISMARK_SUMMARY {
         'quay.io/biocontainers/bismark:0.24.0--hdfd78af_0' }"
 
     input:
-    path(bam)
+    val(bam)
     path(align_report)
     path(dedup_report)
     path(splitting_report)
@@ -23,7 +23,7 @@ process BISMARK_SUMMARY {
     script:
     def args = task.ext.args ?: ''
     """
-    bismark2summary
+    bismark2summary ${bam.join(' ')}
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/bismark/summary/meta.yml
+++ b/modules/nf-core/bismark/summary/meta.yml
@@ -23,25 +23,25 @@ tools:
       licence: ["GPL-3.0-or-later"]
 input:
   - bam:
-      type: file
-      description: Bismark alignment
-      pattern: "*.{bam}"
+      type: value
+      description: Array of Bismark alignment BAM filenames
+      pattern: "*.bam"
   - align_report:
       type: file
       description: Bismark alignment reports
-      pattern: "*{report.txt}"
+      pattern: "*report.txt"
   - dedup_report:
       type: file
       description: Bismark deduplication reports
-      pattern: "*.{deduplication_report.txt}"
+      pattern: "*.deduplication_report.txt"
   - splitting_report:
       type: file
       description: Bismark splitting reports
-      pattern: "*{splitting_report.txt}"
+      pattern: "*splitting_report.txt"
   - mbias:
       type: file
       description: Text file containing methylation bias information
-      pattern: "*.{txt}"
+      pattern: "*.txt"
 output:
   - summary:
       type: file

--- a/subworkflows/local/bismark.nf
+++ b/subworkflows/local/bismark.nf
@@ -95,7 +95,7 @@ workflow BISMARK {
      * Generate bismark summary report
      */
     BISMARK_SUMMARY (
-        BISMARK_ALIGN.out.bam.collect{ it[1] }.ifEmpty([]),
+        BISMARK_ALIGN.out.bam.collect{ it[1].name }.ifEmpty([]),
         alignment_reports.collect{ it[1] }.ifEmpty([]),
         alignment_reports.collect{ it[2] }.ifEmpty([]),
         BISMARK_METHYLATIONEXTRACTOR.out.report.collect{ it[1] }.ifEmpty([]),


### PR DESCRIPTION
Update the bismark/summary module and change the channel handling so that we pass BAM filenames, and not files. This prevents the massive BAM files from being staged into the work directories whilst allowing the summary report to still be generated.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] `CHANGELOG.md` is updated.