### PR TITLE
Fixed Bismark and bwa-meth index locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 - 🐛 Fixed typo in parameter handling for input reference indices ([#263](https://github.com/nf-core/methylseq/issues/263))
 - 🧹 Removed orphaned `--bismark_align_cpu_per_multicore` and `--bismark_align_cpu_per_multicore` parameters.
   - Multi-core usage for Bismark alignment is now automatically set. If you would like to overwrite this, you can do so by setting `ext.args` for the process in a custom config.
+- 🐛 Fixed bug where the index for Bismark or bwa-meth had been specified (incorrectly) as `bismark_index` or `bwameth_index` ([#273](https://github.com/nf-core/methylseq/pull/273))
+- Addressed issue [#273](https://github.com/nf-core/methylseq/issues/271): removed duplicate option `coverage2cytosine`. Use the existing option `--cytosine_report` to launch the new `COVERAGE2CYTOSINE` process. Removed option `--cytosine_report genome_index` from methylation extractor.
 
 ### Software Updates
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - 🧹 Removed orphaned `--bismark_align_cpu_per_multicore` and `--bismark_align_cpu_per_multicore` parameters.
   - Multi-core usage for Bismark alignment is now automatically set. If you would like to overwrite this, you can do so by setting `ext.args` for the process in a custom config.
 - 🐛 Fixed bug where the index for Bismark or bwa-meth had been specified (incorrectly) as `bismark_index` or `bwameth_index` ([#273](https://github.com/nf-core/methylseq/pull/273))
-- Addressed issue [#273](https://github.com/nf-core/methylseq/issues/271): removed duplicate option `coverage2cytosine`. Use the existing option `--cytosine_report` to launch the new `COVERAGE2CYTOSINE` process. Removed option `--cytosine_report genome_index` from methylation extractor.
+- Removed duplicate option `--coverage2cytosine`. Use the existing option `--cytosine_report` to launch the new `COVERAGE2CYTOSINE` process. Removed option `--cytosine_report genome_index` from methylation extractor. ([#273](https://github.com/nf-core/methylseq/issues/273))
 
 ### Software Updates
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -207,7 +207,6 @@ process {
     withName: BISMARK_METHYLATIONEXTRACTOR {
         ext.args = { [
             params.comprehensive   ? ' --comprehensive --merge_non_CpG' : '',
-            params.cytosine_report ? ' --cytosine_report --genome_folder BismarkIndex' : '',
             params.meth_cutoff     ? " --cutoff ${params.meth_cutoff}" : '',
             params.nomeseq         ? '--CX' : '',
             meta.single_end ? '' : (params.no_overlap           ? ' --no_overlap'                         : '--include_overlap'),
@@ -277,6 +276,7 @@ process {
             pattern: "*.html"
         ]
     }
+
 
     withName: BISMARK_SUMMARY {
         ext.args = ''

--- a/main.nf
+++ b/main.nf
@@ -20,8 +20,8 @@ nextflow.enable.dsl = 2
 
 params.fasta = WorkflowMain.getGenomeAttribute(params, 'fasta')
 params.fasta_index = WorkflowMain.getGenomeAttribute(params, 'fasta_index')
-params.bismark_index = WorkflowMain.getGenomeAttribute(params, 'bismark_index')
-params.bwa_meth_index = WorkflowMain.getGenomeAttribute(params, 'bwa_meth_index')
+params.bismark_index = WorkflowMain.getGenomeAttribute(params, 'bismark')
+params.bwa_meth_index = WorkflowMain.getGenomeAttribute(params, 'bwa_meth')
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/nextflow.config
+++ b/nextflow.config
@@ -69,7 +69,6 @@ params {
     local_alignment            = false
     minins                     = null
     maxins                     = null
-    coverage2cytosine          = false
     nomeseq                    = false
 
     // bwa-meth options

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -271,7 +271,7 @@
                 },
                 "cytosine_report": {
                     "type": "boolean",
-                    "description": "Output stranded cytosine report during Bismark's bismark_methylation_extractor step.",
+                    "description": "Output stranded cytosine report, following Bismark's bismark_methylation_extractor step.",
                     "help_text": "By default, Bismark does not produce stranded calls. With this option the output considers all Cs on both forward and reverse strands and reports their position, strand, trinucleotide context and methylation state.",
                     "fa_icon": "fas fa-clipboard"
                 },
@@ -338,11 +338,6 @@
                     "fa_icon": "fas fa-expand-alt",
                     "description": "The maximum insert size for valid paired-end alignments.",
                     "help_text": "For example, if `--maxins 100` is specified and a paired-end alignment consists of two 20-bp alignments in the proper orientation with a 60-bp gap between them, that alignment is considered valid (as long as `--minins` is also satisfied). A 61-bp gap would not be valid in that case.\n\nDefault: not specified. Bismark default: `500`."
-                },
-                "coverage2cytosine": {
-                    "type": "boolean",
-                    "fa_icon": "fas fa-align-center",
-                    "description": "Run bismark coverage2cytosine."
                 },
                 "nomeseq": {
                     "type": "boolean",

--- a/subworkflows/local/bismark.nf
+++ b/subworkflows/local/bismark.nf
@@ -73,7 +73,7 @@ workflow BISMARK {
     /*
      * Run coverage2cytosine
      */
-    if (params.coverage2cytosine || params.nomeseq) {
+    if (params.cytosine_report || params.nomeseq) {
         BISMARK_COVERAGE2CYTOSINE (
             BISMARK_METHYLATIONEXTRACTOR.out.coverage,
             bismark_index


### PR DESCRIPTION
<!--
# nf-core/methylseq pull request

Many thanks for contributing to nf-core/methylseq!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/methylseq/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/methylseq/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/methylseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).

This commit fixes the index locations for Bismark and bwa-meth 
