### PR TITLE
Wrap `params.fasta` with `file()` when used in processes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Pipeline Updates
 
+- 🐛 Fix a bug with using a local genome reference FASTA file
 - 🐛 Fix a bunch of problems in the CI tests using nf-test ([#279](https://github.com/nf-core/methylseq/pull/279))
 
 ## [v2.2.0](https://github.com/nf-core/methylseq/releases/tag/2.2.0) - 2022-11-29

--- a/subworkflows/local/bismark.nf
+++ b/subworkflows/local/bismark.nf
@@ -24,7 +24,7 @@ workflow BISMARK {
     if (params.bismark_index) {
         bismark_index = file(params.bismark_index)
     } else {
-        BISMARK_GENOMEPREPARATION(params.fasta)
+        BISMARK_GENOMEPREPARATION(file(params.fasta))
         bismark_index = BISMARK_GENOMEPREPARATION.out.index
         versions = versions.mix(BISMARK_GENOMEPREPARATION.out.versions)
     }

--- a/subworkflows/local/bwameth.nf
+++ b/subworkflows/local/bwameth.nf
@@ -27,7 +27,7 @@ workflow BWAMETH {
     if (params.bwa_meth_index) {
         bwameth_index = file(params.bwa_meth_index)
     } else {
-        BWAMETH_INDEX(params.fasta)
+        BWAMETH_INDEX(file(params.fasta))
         bwameth_index = BWAMETH_INDEX.out.index
         versions = versions.mix(BWAMETH_INDEX.out.versions)
     }
@@ -38,7 +38,7 @@ workflow BWAMETH {
     if (params.fasta_index) {
         fasta_index = file(params.fasta_index)
     } else {
-        SAMTOOLS_FAIDX([[:], params.fasta])
+        SAMTOOLS_FAIDX([[:], file(params.fasta)])
         fasta_index = SAMTOOLS_FAIDX.out.fai.map{ return(it[1])}
         versions = versions.mix(SAMTOOLS_FAIDX.out.versions)
     }
@@ -83,7 +83,7 @@ workflow BWAMETH {
         */
         PICARD_MARKDUPLICATES (
             SAMTOOLS_SORT.out.bam,
-            params.fasta,
+            file(params.fasta),
             fasta_index
         )
         /*
@@ -105,12 +105,12 @@ workflow BWAMETH {
 
     METHYLDACKEL_EXTRACT(
         alignments.join(bam_index),
-        params.fasta,
+        file(params.fasta),
         fasta_index
     )
     METHYLDACKEL_MBIAS(
         alignments.join(bam_index),
-        params.fasta,
+        file(params.fasta),
         fasta_index
     )
     versions = versions.mix(METHYLDACKEL_EXTRACT.out.versions)


### PR DESCRIPTION
Fixes bug where a local file would not work


- [x] This comment contains a description of changes (with reason).
- [x] `CHANGELOG.md` is updated.
