### PR TITLE
Add config for longer timeouts on Bismark + bwameth alignment processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Pipeline Updates
 
+- ⚙️ Dramatically increase the default process time config requests for Bismark and bwa meth alignment
 - 🧹 Refactor genome indices preparation into a separate workflow
 - 🧹 Refactor subworkflow logic out of alignment subworkflows, for later sharing
 - 🐛 Fix a bug with using a local genome reference FASTA file

--- a/conf/base.config
+++ b/conf/base.config
@@ -61,4 +61,16 @@ process {
     withName:CUSTOM_DUMPSOFTWAREVERSIONS {
         cache = false
     }
+    withName: BISMARK_ALIGN {
+        time = { check_max( 8.d * task.attempt, 'time' ) }
+    }
+    withName: BISMARK_DEDUPLICATE {
+        time = { check_max( 2.d * task.attempt, 'time' ) }
+    }
+    withName: BISMARK_METHYLATIONEXTRACTOR {
+        time = { check_max( 1.d * task.attempt, 'time' ) }
+    }
+    withName: BWAMETH_ALIGN {
+        time = { check_max( 6.d * task.attempt, 'time' ) }
+    }
 }


### PR DESCRIPTION
Reverting back to some of the durations originally set in the DSL1 version of the pipeline: https://github.com/nf-core/methylseq/blob/1.6.1/conf/base.config

Should solve many of the problems we've been seeing with pipelines failing due to the alignment step timing out since the DSL2 conversion.