### PR TITLE
remove unused output folder

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -230,11 +230,6 @@ process {
                 pattern: "*bedGraph.gz"
             ],
             [
-                path: { "${params.outdir}/${params.aligner}/methylation_calls/stranded_CpG_report" },
-                mode: params.publish_dir_mode,
-                pattern: "*CpG_report.txt.gz"
-            ],
-            [
                 path: { "${params.outdir}/${params.aligner}/methylation_calls/splitting_report" },
                 mode: params.publish_dir_mode,
                 pattern: "*splitting_report.txt"


### PR DESCRIPTION
Apparently the `./results/bismark/methylation_calls/stranded_CpG_report/` directory is no longer used. The files previously produced by `BISMARK_METHYLATIONEXTRACTOR` are now produced by `COVERAGE2CYTOSINE` and can be found in `/results/bismark/coverage2cytosine/reports`.