### PR TITLE
Add bismark --ignore and --ignore_3prime options 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bug fixes & refactoring
 
-- Nothing yet..
+- 🐛 fix `ignore_3prime_r2` param #299
 
 ## [v2.3.0](https://github.com/nf-core/methylseq/releases/tag/2.3.0) - 2022-12-16
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -210,8 +210,10 @@ process {
             params.meth_cutoff     ? " --cutoff ${params.meth_cutoff}" : '',
             params.nomeseq         ? '--CX' : '',
             meta.single_end ? '' : (params.no_overlap           ? ' --no_overlap'                         : '--include_overlap'),
+            params.ignore        > 0 ? "--ignore ${params.ignore}"       : "",
+            params.ignore_3prime > 0 ? "--ignore_3prime ${params.ignore_3prime}": "",
             meta.single_end ? '' : (params.ignore_r2        > 0 ? "--ignore_r2 ${params.ignore_r2}"       : ""),
-            meta.single_end ? '' : (params.ignore_3prime_r2 > 0 ? "--ignore_r2 ${params.ignore_3prime_r2}": "")
+            meta.single_end ? '' : (params.ignore_3prime_r2 > 0 ? "--ignore_3prime_r2 ${params.ignore_3prime_r2}": "")
         ].join(' ').trim() }
         publishDir = [
             [

--- a/lib/WorkflowMethylseq.groovy
+++ b/lib/WorkflowMethylseq.groovy
@@ -13,8 +13,10 @@ class WorkflowMethylseq {
     public static void initialise(params, log) {
         genomeExistsError(params, log)
 
-        if (!params.fasta && params.aligner != 'bismark') {
-            Nextflow.error "Genome fasta file not specified with e.g. '--fasta genome.fa' or via a detectable config file."
+        if (!params.fasta) {
+            if (!params.bismark_index || params.aligner != 'bismark') {
+                Nextflow.error "Genome fasta file not specified with e.g. '--fasta genome.fa' or via a detectable config file."
+            }
         }
     }
 

--- a/lib/WorkflowMethylseq.groovy
+++ b/lib/WorkflowMethylseq.groovy
@@ -13,8 +13,7 @@ class WorkflowMethylseq {
     public static void initialise(params, log) {
         genomeExistsError(params, log)
 
-
-        if (!params.fasta) {
+        if (!params.fasta && params.aligner != 'bismark') {
             Nextflow.error "Genome fasta file not specified with e.g. '--fasta genome.fa' or via a detectable config file."
         }
     }

--- a/nextflow.config
+++ b/nextflow.config
@@ -63,7 +63,9 @@ params {
     // Bismark default is 0.2 (L,0,-0.2), Bowtie2 default is 0.6 (L,0,-0.6)
     meth_cutoff                = null
     no_overlap                 = true
+    ignore                     = 0
     ignore_r2                  = 2
+    ignore_3prime              = 0
     ignore_3prime_r2           = 2
     known_splices              = null
     local_alignment            = false

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -92,7 +92,7 @@
                     "mimetype": "text/plain",
                     "pattern": "^\\S+\\.fn?a(sta)?$",
                     "description": "Path to FASTA genome file",
-                    "help_text": "If you have no genome reference available, the pipeline can build one using a FASTA file. This requires additional time and resources, so it's better to use a pre-build index if possible. You can use the command line option `--save_reference` to keep the generated references so that they can be added to your config and used again in the future. If using Bismark, this parameter is ignored."
+                    "help_text": "If you have no genome reference available, the pipeline can build one using a FASTA file. This requires additional time and resources, so it's better to use a pre-build index if possible. You can use the command line option `--save_reference` to keep the generated references so that they can be added to your config and used again in the future. If aligner is Bismark and bismark_index is specified, this parameter is ignored."
                 },
                 "fasta_index": {
                     "type": "string",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -92,7 +92,7 @@
                     "mimetype": "text/plain",
                     "pattern": "^\\S+\\.fn?a(sta)?$",
                     "description": "Path to FASTA genome file",
-                    "help_text": "If you have no genome reference available, the pipeline can build one using a FASTA file. This requires additional time and resources, so it's better to use a pre-build index if possible. You can use the command line option `--save_reference` to keep the generated references so that they can be added to your config and used again in the future."
+                    "help_text": "If you have no genome reference available, the pipeline can build one using a FASTA file. This requires additional time and resources, so it's better to use a pre-build index if possible. You can use the command line option `--save_reference` to keep the generated references so that they can be added to your config and used again in the future. If using Bismark, this parameter is ignored."
                 },
                 "fasta_index": {
                     "type": "string",
@@ -301,10 +301,24 @@
                     "help_text": "For paired-end reads it is theoretically possible that read_1 and read_2 overlap. To avoid scoring overlapping methylation calls twice, this is set to `true` by default. (Only methylation calls of read 1 are used since read 1 has historically higher quality basecalls than read 2). Whilst this option removes a bias towards more methylation calls in the center of sequenced fragments it may de facto remove a sizable proportion of the data. To count methylation data from both reads in overlapping regions, set this to `false`. ",
                     "fa_icon": "fas fa-allergies"
                 },
+                "ignore": {
+                    "type": "integer",
+                    "default": 0,
+                    "description": "Ignore methylation in first n bases of 5' end of R1",
+                    "help_text": "Ignore the first <int> bp from the 5' end of Read 1 (or single-end alignment files) when processing the methylation call string. This can remove e.g. a restriction enzyme site at the start of each read or any other source of bias (such as PBAT-Seq data).",
+                    "fa_icon": "far fa-eye-slash"
+                },
                 "ignore_r2": {
                     "type": "integer",
                     "default": 2,
                     "description": "Ignore methylation in first n bases of 5' end of R2",
+                    "help_text": "Ignore the first <int> bp from the 5' end of Read 2 of paired-end sequencing results only. Since the first couple of bases in Read 2 of BS-Seq experiments show a severe bias towards non-methylation as a result of end-repairing sonicated fragments with unmethylated cytosines (see M-bias plot), it is recommended that the first couple of bp of Read 2 are removed before starting downstream analysis. Please see the section on M-bias plots in the Bismark User Guide for more details.",
+                    "fa_icon": "far fa-eye-slash"
+                },
+                "ignore_3prime": {
+                    "type": "integer",
+                    "default": 0,
+                    "description": "Ignore methylation in last n bases of 3' end of R1",
                     "help_text": "Ignore the first <int> bp from the 5' end of Read 2 of paired-end sequencing results only. Since the first couple of bases in Read 2 of BS-Seq experiments show a severe bias towards non-methylation as a result of end-repairing sonicated fragments with unmethylated cytosines (see M-bias plot), it is recommended that the first couple of bp of Read 2 are removed before starting downstream analysis. Please see the section on M-bias plots in the Bismark User Guide for more details.",
                     "fa_icon": "far fa-eye-slash"
                 },


### PR DESCRIPTION
1. Bismark methylation extractor has four flags to ignore bases. This PR adds two (`--ignore` and `--ignore_3prime`) that were missing.
2. `--fasta` flag is ignored when bismark aligner is used. This PR makes `--fasta` as a not required flag when `params.aligner` is bismark.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/methylseq/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/methylseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
