### PR TITLE
Leave spare memory for samtools sort (again)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Pipeline Updates
 
 ### Bug fixes & refactoring
+- 🐛 leave some spare memory for samtools sort (again) #81
 
 ## [v2.4.0](https://github.com/nf-core/methylseq/releases/tag/2.4.0) - 2023-06-02
 

--- a/modules/nf-core/samtools/sort/main.nf
+++ b/modules/nf-core/samtools/sort/main.nf
@@ -25,11 +25,11 @@ process SAMTOOLS_SORT {
     if ("$bam" == "${prefix}.bam") error "Input and output names are the same, use \"task.ext.prefix\" to disambiguate!"
     """
     samtools sort \\
-        $args \\
         -@ $task.cpus \\
         -m ${sort_memory}M \\
         -o ${prefix}.bam \\
         -T $prefix \\
+        $args \\
         $bam
 
     cat <<-END_VERSIONS > versions.yml

--- a/modules/nf-core/samtools/sort/main.nf
+++ b/modules/nf-core/samtools/sort/main.nf
@@ -21,7 +21,7 @@ process SAMTOOLS_SORT {
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def sort_memory = (task.memory.mega/task.cpus).intValue()
+    def sort_memory = (task.memory.mega-6000/task.cpus).intValue()
     if ("$bam" == "${prefix}.bam") error "Input and output names are the same, use \"task.ext.prefix\" to disambiguate!"
     """
     samtools sort \\


### PR DESCRIPTION
This PR fixes #81 (again). It was originally fixed in #82, but this fix got lost apparently when splitting the configuration into modules.

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [X] Make sure your code lints (`nf-core lint`).
- [X] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [X] `CHANGELOG.md` is updated.
