### PR TITLE
Publish coverage files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Bug fixes & refactoring
 
+- 🛠️ Added publishing of coverage (`*cov.gz`) files for NOMe-seq filtered reads for `coverage2cytosine`
+
 ## [v2.4.0](https://github.com/nf-core/methylseq/releases/tag/2.4.0) - 2023-06-02
 
 ### Pipeline Updates

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -256,6 +256,11 @@ process {
                 path: { "${params.outdir}/bismark/coverage2cytosine/reports" },
                 mode: params.publish_dir_mode,
                 pattern: "*_report.txt.gz"
+            ],
+            publishDir = [
+                path: { "${params.outdir}/bismark/coverage2cytosine/coverage" },
+                mode: params.publish_dir_mode,
+                pattern: "*cov.gz"
             ]
         ]
     }


### PR DESCRIPTION
For NOMe-seq runs, the `coverage2cytosine` module produces both `CpG_report.txt.gz` and `GpC_report.txt.gz` text files; in addition, it also generates these information in the form of coverage files (ending in `*.cov.gz`), however these files do not get published at all. 

This PR adds a new publishing rule for CpG/GpC coverage files.

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/methylseq/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/methylseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [X] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
