### PR TITLE
Maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @nf-core/methylseq

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Updated nf-core modules for FastQC, samtools sort, samtools flagstat
   - Removes problematic `-m` memory assignment for samtools sort [#81](https://github.com/nf-core/methylseq/issues/81)
 - Use `fromSamplesheet` from nf-validation [#341](https://github.com/nf-core/methylseq/pull/341)
+- Update Maintainers and add CODEOWNERS [#345](https://github.com/nf-core/methylseq/pull/345)
 
 ### Bug fixes & refactoring
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ These scripts were originally written for use at the [National Genomics Infrastr
 
 - Main author:
   - Phil Ewels ([@ewels](https://github.com/ewels/))
+- Maintainers:
+  - Felix Krueger ([@FelixKrueger](https://github.com/FelixKrueger))
+  - Sateesh Peri ([@Sateesh_Peri](https://github.com/sateeshperi))
+  - Edmund Miller ([@EMiller88](https://github.com/emiller88))
 - Contributors:
   - Rickard Hammarén ([@Hammarn](https://github.com/Hammarn/))
   - Alexander Peltzer ([@apeltzer](https://github.com/apeltzer/))


### PR DESCRIPTION
Proposing we make this thing official. 

@njspix Let me know if you want in as well! Just didn't want to sign you up.

Anyone else seeing this that would like to make sure this pipeline stays up to date feel free to reach out!

@ewels Could we get a new team made in the nf-core org. I think a sub-team under a pipelines team, then that'll give us an automatic "pipeline maintainers" team. 