### PR TITLE
Add length_trim parameter to nextflow.config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Pipeline Updates
 
 - 🔧 Updated nf-core modules for preseq [#390](https://github.com/nf-core/methylseq/pull/390)
+- 🔧 Added new trimgalore length_trim param [#416](https://github.com/nf-core/methylseq/pull/416)
 
 ## [v2.6.0](https://github.com/nf-core/methylseq/releases/tag/2.6.0) - 2024-01-05
 

--- a/modules/nf-core/trimgalore/nextflow.config
+++ b/modules/nf-core/trimgalore/nextflow.config
@@ -7,6 +7,7 @@ process {
             // Special flags
             params.rrbs ? '--rrbs' : '',
             params.nextseq_trim > 0 ? "--nextseq ${params.nextseq_trim}" : '',
+            params.length_trim ? "--length ${params.length_trim}" : '',
 
             // Trimming - R1
             params.clip_r1 > 0 ? "--clip_r1 ${params.clip_r1}" : (

--- a/nextflow.config
+++ b/nextflow.config
@@ -56,6 +56,7 @@ params {
     three_prime_clip_r1        = 0
     three_prime_clip_r2        = 0
     nextseq_trim               = 0
+    length_trim                = null
 
     // Bismark options
     non_directional            = false

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -255,6 +255,11 @@
                     "type": "integer",
                     "default": 0,
                     "description": "Trim bases below this quality value from the 3' end of the read, ignoring high-quality G bases"
+                },
+                "length_trim": {
+                    "type": "integer",
+                    "description": "Discard reads that become shorter than INT because of either quality or adapter trimming.",
+                    "fa_icon": "fas fa-trash-alt"
                 }
             },
             "fa_icon": "fas fa-cut",
@@ -669,13 +674,18 @@
             "$ref": "#/definitions/skip_pipeline_steps"
         },
         {
-            "$ref": "#/definitions/generic_options"
+            "$ref": "#/definitions/institutional_config_options"
         },
         {
             "$ref": "#/definitions/max_job_request_options"
         },
         {
-            "$ref": "#/definitions/institutional_config_options"
+            "$ref": "#/definitions/generic_options"
         }
-    ]
+    ],
+    "properties": {
+        "new_param_1": {
+            "type": "string"
+        }
+    }
 }

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -683,9 +683,5 @@
             "$ref": "#/definitions/generic_options"
         }
     ],
-    "properties": {
-        "new_param_1": {
-            "type": "string"
-        }
-    }
+    "properties": {}
 }


### PR DESCRIPTION
Included a new parameter, length_trim, to allow users to specify the minimum acceptable read length after quality and adapter trimming. This enhancement provides greater flexibility in handling quality trimming.

<!--
# nf-core/methylseq pull request

Many thanks for contributing to nf-core/methylseq!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/methylseq/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/methylseq/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/methylseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
