### PR TITLE
Add --skip_trimming_presets to uncouple trimming from alignment modes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         NXF_VER:
-          - "24.04.2"
+          - "24.10.4"
           - "latest-everything"
         profile:
           - "conda"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Pipeline Updates
 
 - 🔧 Added new flag `skip_trimming_presets` to overwrite any preset trimming options [#560](https://github.com/nf-core/methylseq/pull/506)
-- 🔧 Update `--pbat` trimming options to 8|8|8|8 [#560](https://github.com/nf-core/methylseq/pull/506) 
+- 🔧 Update `--pbat` trimming options to 8|8|8|8 [#560](https://github.com/nf-core/methylseq/pull/506)
 - 🔄 Removed `--cegx` and `--epignome` preset trimming options (kits discontinued) [#560](https://github.com/nf-core/methylseq/pull/506)
-
 
 ## [v3.0.0](https://github.com/nf-core/methylseq/releases/tag/3.0.0) - [2024-12-16]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Pipeline Updates
 
--
+- 🔧 added new flag `skip_trimming_presets` to overwrite any preset trimming options
+- 🔧 update `pbat` trimming options to 8|8|8|8
+- 🔄 removed `cegx` and `epignome` preset trimming options (kits discontinued) 
+
+
 
 ## [v3.0.0](https://github.com/nf-core/methylseq/releases/tag/3.0.0) - [2024-12-16]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Pipeline Updates
 
-- 🔧 Added new flag `skip_trimming_presets` to overwrite any preset trimming options
-- 🔧 Update `--pbat` trimming options to 8|8|8|8
-- 🔄 Removed `--cegx` and `--epignome` preset trimming options (kits discontinued) 
-
+- 🔧 Added new flag `skip_trimming_presets` to overwrite any preset trimming options [#560](https://github.com/nf-core/methylseq/pull/506)
+- 🔧 Update `--pbat` trimming options to 8|8|8|8 [#560](https://github.com/nf-core/methylseq/pull/506) 
+- 🔄 Removed `--cegx` and `--epignome` preset trimming options (kits discontinued) [#560](https://github.com/nf-core/methylseq/pull/506)
 
 
 ## [v3.0.0](https://github.com/nf-core/methylseq/releases/tag/3.0.0) - [2024-12-16]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Pipeline Updates
 
-- 🔧 added new flag `skip_trimming_presets` to overwrite any preset trimming options
-- 🔧 update `pbat` trimming options to 8|8|8|8
-- 🔄 removed `cegx` and `epignome` preset trimming options (kits discontinued) 
+- 🔧 Added new flag `skip_trimming_presets` to overwrite any preset trimming options
+- 🔧 Update `--pbat` trimming options to 8|8|8|8
+- 🔄 Removed `--cegx` and `--epignome` preset trimming options (kits discontinued) 
 
 
 

--- a/conf/modules/trimgalore.config
+++ b/conf/modules/trimgalore.config
@@ -11,9 +11,9 @@ process {
 
             // Trimming - R1
             params.clip_r1 > 0 ? "--clip_r1 ${params.clip_r1}" : (
-                params.pbat ? "--clip_r1 9" : (
-                    (params.single_cell || params.cegx) ? "--clip_r1 6" : (
-                        params.epignome ? "--clip_r1 8" : (
+                params.skip_trimming_presets ? '' : (
+                    params.pbat ? "--clip_r1 8" : (
+                        params.single_cell ? "--clip_r1 6" : (
                             (params.accel || params.zymo || params.em_seq) ? "--clip_r1 10" : ''
                         )
                     )

--- a/conf/modules/trimgalore.config
+++ b/conf/modules/trimgalore.config
@@ -27,12 +27,12 @@ process {
                         params.pbat ? "--clip_r2 8" : (
                             params.single_cell ? "--clip_r2 6" : (
                                 (params.zymo || params.em_seq) ? "--clip_r2 10" : (
-                                        params.accel ? "--clip_r2 15" : ''
+                                    params.accel ? "--clip_r2 15" : ''
                                 )
                             )
                         )
                     )
-                )    
+                )
             ),
 
             // Trimming - 3' R1
@@ -41,8 +41,8 @@ process {
                     params.pbat ? "--three_prime_clip_r1 8" : (
                         params.single_cell ? "--three_prime_clip_r1 6" : (
                             (params.accel || params.zymo || params.em_seq) ? "--three_prime_clip_r1 10" : ''
-                        )    
-                    )               
+                        )
+                    )
                 )
             ),
 

--- a/conf/modules/trimgalore.config
+++ b/conf/modules/trimgalore.config
@@ -23,40 +23,36 @@ process {
             // Trimming - R2
             meta.single_end ? '' : (
                 params.clip_r2 > 0 ? "--clip_r2 ${params.clip_r2}" : (
-                    params.pbat ? "--clip_r2 9" : (
-                        (params.single_cell || params.cegx) ? "--clip_r2 6" : (
-                            params.epignome ? "--clip_r2 8" : (
+                    params.skip_trimming_presets ? '' : (
+                        params.pbat ? "--clip_r2 8" : (
+                            params.single_cell ? "--clip_r2 6" : (
                                 (params.zymo || params.em_seq) ? "--clip_r2 10" : (
-                                    params.accel ? "--clip_r2 15" : ''
+                                        params.accel ? "--clip_r2 15" : ''
                                 )
                             )
                         )
                     )
-                )
+                )    
             ),
 
             // Trimming - 3' R1
             params.three_prime_clip_r1 > 0 ? "--three_prime_clip_r1 ${params.three_prime_clip_r1}" : (
-                params.pbat ? "--three_prime_clip_r1 9" : (
-                    params.single_cell ? "--three_prime_clip_r1 6" : (
-                        params.cegx ? "--three_prime_clip_r1 2" : (
-                            params.epignome ? "--three_prime_clip_r1 8" : (
-                                (params.accel || params.zymo || params.em_seq) ? "--three_prime_clip_r1 10" : ''
-                            )
-                        )
-                    )
+                params.skip_trimming_presets ? '' : (
+                    params.pbat ? "--three_prime_clip_r1 8" : (
+                        params.single_cell ? "--three_prime_clip_r1 6" : (
+                            (params.accel || params.zymo || params.em_seq) ? "--three_prime_clip_r1 10" : ''
+                        )    
+                    )               
                 )
             ),
 
             // Trimming - 3' R2
             meta.single_end ? '' : (
                 params.three_prime_clip_r2 > 0 ? "--three_prime_clip_r2 ${params.three_prime_clip_r2}" : (
-                    params.pbat ? "--three_prime_clip_r2 9" : (
-                        params.single_cell ? "--three_prime_clip_r2 6" : (
-                            params.cegx ? "--three_prime_clip_r2 2" : (
-                                params.epignome ? "--three_prime_clip_r2 8" : (
-                                    (params.accel || params.zymo || params.em_seq) ? "--three_prime_clip_r2 10" : ''
-                                )
+                    params.skip_trimming_presets ? '' : (
+                        params.pbat ? "--three_prime_clip_r2 8" : (
+                            params.single_cell ? "--three_prime_clip_r2 6" : (
+                                (params.accel || params.zymo || params.em_seq) ? "--three_prime_clip_r2 10" : ''
                             )
                         )
                     )

--- a/nextflow.config
+++ b/nextflow.config
@@ -41,8 +41,6 @@ params {
     em_seq                       = false
     single_cell                  = false
     accel                        = false
-    cegx                         = false
-    epignome                     = false
     zymo                         = false
 
     // Trimming options

--- a/nextflow.config
+++ b/nextflow.config
@@ -52,6 +52,7 @@ params {
     three_prime_clip_r2          = 0
     nextseq_trim                 = 0
     length_trim                  = null
+    skip_trimming_presets        = false
 
     // Bismark options
     non_directional              = false

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -169,7 +169,7 @@
                     "type": "boolean",
                     "fa_icon": "fas fa-outdent",
                     "description": "Preset for working with PBAT libraries.",
-                    "help_text": "Specify this parameter when working with PBAT _(Post Bisulfite Adapter Tagging)_ libraries.\n\nUsing this parameter sets the `--pbat` flag when aligning with Bismark. This tells Bismark to align complementary strands (the opposite of `--directional`).\n\nAdditionally, this is a trimming preset equivalent to `--clip_r1 6` `--clip_r2 9` `--three_prime_clip_r1 6` `--three_prime_clip_r2 9`"
+                    "help_text": "Specify this parameter when working with PBAT _(Post Bisulfite Adapter Tagging)_ libraries.\n\nUsing this parameter sets the `--pbat` flag when aligning with Bismark. This tells Bismark to align complementary strands (the opposite of `--directional`).\n\nAdditionally, this is a trimming preset equivalent to `--clip_r1 8` `--clip_r2 8` `--three_prime_clip_r1 8` `--three_prime_clip_r2 8`, unless `--skip_trimming_presets` is set to `true`"
                 },
                 "rrbs": {
                     "type": "boolean",
@@ -200,18 +200,6 @@
                     "fa_icon": "fas fa-cut",
                     "help_text": "Equivalent to `--clip_r1 10` `--clip_r2 15` `--three_prime_clip_r1 10` `--three_prime_clip_r2 10`",
                     "description": "Trimming preset for the Accel kit."
-                },
-                "cegx": {
-                    "type": "boolean",
-                    "fa_icon": "fas fa-cut",
-                    "description": "Trimming preset for the CEGX bisulfite kit.",
-                    "help_text": "Equivalent to `--clip_r1 6` `--clip_r2 6` `--three_prime_clip_r1 2` `--three_prime_clip_r2 2`"
-                },
-                "epignome": {
-                    "type": "boolean",
-                    "fa_icon": "fas fa-cut",
-                    "description": "Trimming preset for the Epignome kit.",
-                    "help_text": "Equivalent to `--clip_r1 8` `--clip_r2 8` `--three_prime_clip_r1 8` `--three_prime_clip_r2 8`"
                 },
                 "zymo": {
                     "type": "boolean",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -213,7 +213,7 @@
         "adapter_trimming": {
             "title": "Adapter Trimming",
             "type": "object",
-            "description": "Bisulfite libraries often require additional base pairs to be removed from the ends of the reads before alignment.",
+            "description": "Bisulfite libraries often require additional base pairs to be removed from the ends of the reads before alignment.\n\nIn addition to manually specifying bases to be hard-clipped, the workflow has a number of parameter presets:\n\n| Parameter  | 5' R1 Trim | 5' R2 Trim | 3' R1 Trim | 3' R2 Trim | \n|-----------------|------------|------------|------------|------------|\n| `--pbat`        | 8          | 8          | 8          | 8          |\n| `--single_cell` | 6          | 6          | 6          | 6          |\n|  `--accel`      | 10         | 15         | 10         | 10         |\n| `--zymo`        | 10         | 15         | 10         | 10         | \n\nNote that you can use the `--skip_trimming` parameter to skip trimming completely.\nFurther, `--skip_trimming_presets` disables setting any presets for hard-clipping, thereby uncoupling trimming from specific alignment modes entirely",
             "default": "",
             "properties": {
                 "clip_r1": {
@@ -257,8 +257,7 @@
                     "fa_icon": "fas fa-dot-circle"
                 }
             },
-            "fa_icon": "fas fa-cut",
-            "help_text": "In addition to manually specifying bases to be specified, the pipeline has a number of parameter presets:\n\n| Parameter  | 5' R1 Trim | 5' R2 Trim | 3' R1 Trim | 3' R2 Trim | \n|-----------------|------------|------------|------------|------------|\n | `--pbat`        | 8          | 8          | 8          | 8          |\n| `--single_cell` | 6          | 6          | 6          | 6          |\n|  `--accel`       | 10         | 15         | 10         | 10         |\n| `--zymo`        | 10         | 15         | 10         | 10         | \n\nNote that you can use the `--skip_trimming` parameter to skip trimming completely. Also note that `--skip_trimming_presets` will uncouple trimming from specific alignment modes entirely."
+            "fa_icon": "fas fa-cut"
         },
         "bismark_options": {
             "title": "Bismark options",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -258,7 +258,7 @@
                 }
             },
             "fa_icon": "fas fa-cut",
-            "help_text": "In addition to manually specifying bases to be specified, the pipeline has a number of parameter presets:\n\n| Parameter  | 5' R1 Trim | 5' R2 Trim | 3' R1 Trim | 3' R2 Trim | \n|-----------------|------------|------------|------------|------------|\n | `--pbat`        | 8          | 8          | 8          | 8          |\n| `--single_cell` | 6          | 6          | 6          | 6          |\n|  `--accel`       | 10         | 15         | 10         | 10         |\n| `--zymo`        | 10         | 15         | 10         | 10         | \n\nNote that you can use the `--skip_trimming` parameter to skip trimming completely. Also note that `--skip_trimming_presets` will overwrite these presets, thereby uncoupling the trimming presets from alignment mode."
+            "help_text": "In addition to manually specifying bases to be specified, the pipeline has a number of parameter presets:\n\n| Parameter  | 5' R1 Trim | 5' R2 Trim | 3' R1 Trim | 3' R2 Trim | \n|-----------------|------------|------------|------------|------------|\n | `--pbat`        | 8          | 8          | 8          | 8          |\n| `--single_cell` | 6          | 6          | 6          | 6          |\n|  `--accel`       | 10         | 15         | 10         | 10         |\n| `--zymo`        | 10         | 15         | 10         | 10         | \n\nNote that you can use the `--skip_trimming` parameter to skip trimming completely. Also note that `--skip_trimming_presets` will uncouple trimming from specific alignment modes entirely."
         },
         "bismark_options": {
             "title": "Bismark options",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -261,6 +261,12 @@
                     "type": "integer",
                     "description": "Discard reads that become shorter than INT because of either quality or adapter trimming.",
                     "fa_icon": "fas fa-trash-alt"
+                },
+                "skip_trimming_presets": {
+                    "type": "boolean",
+                    "description": "Skip presetting trimming parameters entirely",
+                    "default": false,
+                    "fa_icon": "fas fa-dot-circle"
                 }
             },
             "fa_icon": "fas fa-cut",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -258,7 +258,7 @@
                 }
             },
             "fa_icon": "fas fa-cut",
-            "help_text": "In addition to manually specifying bases to be specified, the pipeline has a number of parameter presets:\n\n| Parameter       | 5' R1 Trim | 5' R2 Trim | 3' R1 Trim | 3' R2 Trim |\n|-----------------|------------|------------|------------|------------|\n| `--pbat`        | 6          | 9          | 6          | 9          |\n| `--single_cell` | 6          | 6          | 6          | 6          |\n| `--epignome`    | 8          | 8          | 8          | 8          |\n| `--accel`       | 10         | 15         | 10         | 10         |\n| `--zymo`        | 10         | 15         | 10         | 10         |\n| `--cegx`        | 6          | 6          | 2          | 2          |\n\nNote that you can use the `--skip_trimming` parameter to skip trimming completely."
+            "help_text": "In addition to manually specifying bases to be specified, the pipeline has a number of parameter presets:\n\n| Parameter  | 5' R1 Trim | 5' R2 Trim | 3' R1 Trim | 3' R2 Trim | \n|-----------------|------------|------------|------------|------------|\n | `--pbat`        | 8          | 8          | 8          | 8          |\n| `--single_cell` | 6          | 6          | 6          | 6          |\n|  `--accel`       | 10         | 15         | 10         | 10         |\n| `--zymo`        | 10         | 15         | 10         | 10         | \n\nNote that you can use the `--skip_trimming` parameter to skip trimming completely."
         },
         "bismark_options": {
             "title": "Bismark options",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -258,7 +258,7 @@
                 }
             },
             "fa_icon": "fas fa-cut",
-            "help_text": "In addition to manually specifying bases to be specified, the pipeline has a number of parameter presets:\n\n| Parameter  | 5' R1 Trim | 5' R2 Trim | 3' R1 Trim | 3' R2 Trim | \n|-----------------|------------|------------|------------|------------|\n | `--pbat`        | 8          | 8          | 8          | 8          |\n| `--single_cell` | 6          | 6          | 6          | 6          |\n|  `--accel`       | 10         | 15         | 10         | 10         |\n| `--zymo`        | 10         | 15         | 10         | 10         | \n\nNote that you can use the `--skip_trimming` parameter to skip trimming completely."
+            "help_text": "In addition to manually specifying bases to be specified, the pipeline has a number of parameter presets:\n\n| Parameter  | 5' R1 Trim | 5' R2 Trim | 3' R1 Trim | 3' R2 Trim | \n|-----------------|------------|------------|------------|------------|\n | `--pbat`        | 8          | 8          | 8          | 8          |\n| `--single_cell` | 6          | 6          | 6          | 6          |\n|  `--accel`       | 10         | 15         | 10         | 10         |\n| `--zymo`        | 10         | 15         | 10         | 10         | \n\nNote that you can use the `--skip_trimming` parameter to skip trimming completely. Also note that `--skip_trimming_presets` will overwrite these presets, thereby uncoupling the trimming presets from alignment mode."
         },
         "bismark_options": {
             "title": "Bismark options",


### PR DESCRIPTION
<!--
# nf-core/methylseq pull request

Many thanks for contributing to nf-core/methylseq!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/methylseq/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

As discussed on Slack, we feel that the trimming presets need to be uncoupled from the alignment mode (e.g. for `--pbat`). We have just added a new option `--skip_trimming_presets` that does just that. We have also updated some of the trimming presets for `--pbat`, and removed outdated options for kits that have been discontinued (`--cegx` and `--epignome`).

- [X] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
