### PR TITLE
Add wave to ARM Megatests

### DIFF
--- a/.github/workflows/awsfulltest.yml
+++ b/.github/workflows/awsfulltest.yml
@@ -60,7 +60,7 @@ jobs:
           compute_env: ${{ matrix.compute_env == 'CPU' && vars.TOWER_COMPUTE_ENV_CPU || matrix.compute_env == 'GPU' && vars.TOWER_COMPUTE_ENV_GPU || vars.TOWER_COMPUTE_ENV_ARM }}
           revision: ${{ steps.revision.outputs.revision }}
           workdir: s3://nf-core-awsmegatests/work/methylseq/work-${{ steps.revision.outputs.revision }}-${{ matrix.aligner }}-${{ matrix.compute_env }}
-          labels: ${{ matrix.compute_env == 'GPU' && 'full_test,gpu' || matrix.compute_env == 'ARM' && 'full_test,arm' || 'full_test' }}
+          labels: ${{ matrix.compute_env == 'GPU' && 'full_test,gpu' || matrix.compute_env == 'ARM' && 'full_test,arm,wave' || 'full_test' }}
           parameters: |
             {
               "hook_url": "${{ secrets.MEGATESTS_ALERTS_SLACK_HOOK_URL }}",


### PR DESCRIPTION
https://nfcore.slack.com/archives/CTY8L26C8/p1753709978577029

@sateeshperi reported 

> Edmund got some errors testing the new testfull yml
```
1:37PM INF instance metadata ami-id=ami-08722c92fea4d0ded instance-id=i-08371ef4086604310 instance-type=m6gd.16xlarge
  Error running command - fork/exec /usr/local/env-execute: exec format error
  Fusion Info:
      kernel_version: 6.1
      disk_cache_size: 3537Gb
      max_open_files: 1048576
      fusion_version: 2.4.13-cd14732
      clone_namespace: false
```

failed run: https://cloud.seqera.io/orgs/nf-core/workspaces/AWSmegatests/watch/1eyNOmQskHS6Q/v2/logs
