### PR TITLE
Update Trim Galore to v2.3.0 (Rust rewrite)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Pipeline Updates
 
+- 🔧 Update Trim Galore to v2.3.0 (the Rust rewrite: faster, single static binary, Cutadapt-free with bundled FastQC). Trimming (and FastQC) outputs change versus 0.6.10 — the Rust engine plus the v2.3.0 R2 3' poly-G fix — so downstream alignment/methylation and MultiQC results shift accordingly.
 - 🔧 Update Bismark to v3.1.0 ([#614](https://github.com/nf-core/methylseq/pull/614))
 - 🔧 Update Bismark to v3.0.0 and refresh the bismark, samtools, bwa, bwameth, methyldackel and parabricks nf-core modules and alignment subworkflows to their latest versions ([#610](https://github.com/nf-core/methylseq/pull/610))
   - Migrated module version reporting to Nextflow topic channels

--- a/modules.json
+++ b/modules.json
@@ -206,7 +206,7 @@
                     },
                     "trimgalore": {
                         "branch": "master",
-                        "git_sha": "e753770db613ce014b3c4bc94f6cba443427b726",
+                        "git_sha": "2a30bfb6a1b4667692d734e33e000a3bd1d74a0d",
                         "installed_by": ["modules"]
                     },
                     "untar": {

--- a/modules/nf-core/trimgalore/environment.yml
+++ b/modules/nf-core/trimgalore/environment.yml
@@ -4,6 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::cutadapt=4.9
-  - bioconda::trim-galore=0.6.10
-  - conda-forge::pigz=2.8
+  - bioconda::trim-galore=2.3.0

--- a/modules/nf-core/trimgalore/main.nf
+++ b/modules/nf-core/trimgalore/main.nf
@@ -1,22 +1,23 @@
 process TRIMGALORE {
     tag "${meta.id}"
-    label 'process_high'
+    label 'process_medium'
+    label 'process_low_memory'
 
     conda "${moduleDir}/environment.yml"
-    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/9b/9becad054093ad4083a961d12733f2a742e11728fe9aa815d678b882b3ede520/data'
-        : 'community.wave.seqera.io/library/cutadapt_trim-galore_pigz:a98edd405b34582d'}"
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/e0/e00369598bd6b7b34a7c83d5496c381104bf8b885c31a4b65b92e6ea2059fbb3/data' :
+        'community.wave.seqera.io/library/trim-galore:2.3.0--6a38a479b4972363'}"
 
     input:
     tuple val(meta), path(reads)
 
     output:
     tuple val(meta), path("*{3prime,5prime,trimmed,val}{,_1,_2}.fq.gz"), emit: reads
-    tuple val(meta), path("*report.txt")                               , emit: log, optional: true
-    tuple val(meta), path("*unpaired{,_1,_2}.fq.gz")                  , emit: unpaired, optional: true
-    tuple val(meta), path("*.html")                                    , emit: html, optional: true
-    tuple val(meta), path("*.zip")                                     , emit: zip, optional: true
-    path "versions.yml"					                               , emit: versions
+    tuple val(meta), path("*report.txt")                               , emit: log     , optional: true
+    tuple val(meta), path("*unpaired{,_1,_2}.fq.gz")                   , emit: unpaired, optional: true
+    tuple val(meta), path("*.html")                                    , emit: html    , optional: true
+    tuple val(meta), path("*.zip")                                     , emit: zip     , optional: true
+    tuple val("${task.process}"), val("trimgalore"), eval('trim_galore --version | grep -Eo "[0-9]+(\\.[0-9]+)+"'), topic: versions, emit: versions_trimgalore
 
     when:
     task.ext.when == null || task.ext.when
@@ -44,7 +45,7 @@ process TRIMGALORE {
     def prefix = task.ext.prefix ?: "${meta.id}"
     if (meta.single_end) {
         def args_list = args.split("\\s(?=--)").toList()
-        args_list.removeAll { it.toLowerCase().contains('_r2 ') }
+        args_list.removeAll { arg -> arg.toLowerCase().contains('_r2 ') }
         """
         [ ! -f  ${prefix}.fastq.gz ] && ln -s ${reads} ${prefix}.fastq.gz
         trim_galore \\
@@ -52,13 +53,6 @@ process TRIMGALORE {
             --cores ${cores} \\
             --gzip \\
             ${prefix}.fastq.gz
-
-        cat <<-END_VERSIONS > versions.yml
-        "${task.process}":
-            trimgalore: \$(echo \$(trim_galore --version 2>&1) | sed 's/^.*version //; s/Last.*\$//')
-            cutadapt: \$(cutadapt --version)
-            pigz: \$( pigz --version 2>&1 | sed 's/pigz //g' )
-        END_VERSIONS
         """
     }
     else {
@@ -72,13 +66,6 @@ process TRIMGALORE {
             --gzip \\
             ${prefix}_1.fastq.gz \\
             ${prefix}_2.fastq.gz
-
-        cat <<-END_VERSIONS > versions.yml
-        "${task.process}":
-            trimgalore: \$(echo \$(trim_galore --version 2>&1) | sed 's/^.*version //; s/Last.*\$//')
-            cutadapt: \$(cutadapt --version)
-            pigz: \$( pigz --version 2>&1 | sed 's/pigz //g' )
-        END_VERSIONS
         """
     }
 
@@ -96,12 +83,5 @@ process TRIMGALORE {
     }
     """
     ${output_command}
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        trimgalore: \$(echo \$(trim_galore --version 2>&1) | sed 's/^.*version //; s/Last.*\$//')
-        cutadapt: \$(cutadapt --version)
-        pigz: \$( pigz --version 2>&1 | sed 's/pigz //g' )
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/trimgalore/meta.yml
+++ b/modules/nf-core/trimgalore/meta.yml
@@ -1,9 +1,11 @@
 name: trimgalore
-description: Trim FastQ files using Trim Galore!
+description: |
+  A wrapper around Cutadapt and FastQC to consistently apply adapter and quality trimming to FastQ files,
+  with extra functionality for RRBS data
 keywords:
   - trimming
   - adapters
-  - sequencing adapters
+  - sequencing
   - fastq
 tools:
   - trimgalore:
@@ -14,7 +16,8 @@ tools:
       homepage: https://www.bioinformatics.babraham.ac.uk/projects/trim_galore/
       documentation: https://github.com/FelixKrueger/TrimGalore/blob/master/Docs/Trim_Galore_User_Guide.md
       licence: ["GPL-3.0-or-later"]
-      identifier: ""
+      identifier: biotools:trim_galore
+
 input:
   - - meta:
         type: map
@@ -26,7 +29,8 @@ input:
         description: |
           List of input FastQ files of size 1 and 2 for single-end and paired-end data,
           respectively.
-        ontologies: []
+        ontologies:
+          - edam: "http://edamontology.org/format_1930" # FASTQ
 output:
   reads:
     - - meta:
@@ -35,11 +39,12 @@ output:
             Groovy Map containing sample information
             e.g. [ id:'test', single_end:false ]
       - "*{3prime,5prime,trimmed,val}{,_1,_2}.fq.gz":
-          type: map
-          description: |
-            Groovy Map containing sample information
-            e.g. [ id:'test', single_end:false ]
+          type: file
+          description: The trimmed/modified fastq reads
           pattern: "*{3prime,5prime,trimmed,val}{,_1,_2}.fq.gz"
+          ontologies:
+            - edam: "http://edamontology.org/format_1930" # FASTQ
+            - edam: http://edamontology.org/format_3989 # GZIP format
   log:
     - - meta:
           type: map
@@ -47,11 +52,11 @@ output:
             Groovy Map containing sample information
             e.g. [ id:'test', single_end:false ]
       - "*report.txt":
-          type: map
-          description: |
-            Groovy Map containing sample information
-            e.g. [ id:'test', single_end:false ]
-          pattern: "*_{report.txt}"
+          type: file
+          description: trimgalore log file
+          pattern: "*report.txt"
+          ontologies:
+            - edam: "http://edamontology.org/format_2330" # Textual format
   unpaired:
     - - meta:
           type: map
@@ -59,11 +64,12 @@ output:
             Groovy Map containing sample information
             e.g. [ id:'test', single_end:false ]
       - "*unpaired{,_1,_2}.fq.gz":
-          type: map
-          description: |
-            Groovy Map containing sample information
-            e.g. [ id:'test', single_end:false ]
+          type: file
+          description: unpaired reads when --retain_unpaired flag is used
           pattern: "*unpaired*.fq.gz"
+          ontologies:
+            - edam: "http://edamontology.org/format_1930" # FASTQ
+            - edam: http://edamontology.org/format_3989 # GZIP format
   html:
     - - meta:
           type: map
@@ -71,11 +77,11 @@ output:
             Groovy Map containing sample information
             e.g. [ id:'test', single_end:false ]
       - "*.html":
-          type: map
-          description: |
-            Groovy Map containing sample information
-            e.g. [ id:'test', single_end:false ]
-          pattern: "*_{fastqc.html}"
+          type: file
+          description: FastQC HTML report after trimming when the --fastqc flag is used
+          pattern: "*_fastqc.html"
+          ontologies:
+            - edam: "http://edamontology.org/format_2331" # HTML
   zip:
     - - meta:
           type: map
@@ -83,18 +89,35 @@ output:
             Groovy Map containing sample information
             e.g. [ id:'test', single_end:false ]
       - "*.zip":
-          type: map
-          description: |
-            Groovy Map containing sample information
-            e.g. [ id:'test', single_end:false ]
-          pattern: "*_{fastqc.zip}"
+          type: file
+          description: FastQC report output zip after trimming when the --fastqc flag
+            is used
+          pattern: "*_fastqc.zip"
+          ontologies:
+            - edam: http://edamontology.org/format_3987 # ZIP format
+  versions_trimgalore:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - trimgalore:
+          type: string
+          description: The name of the tool
+      - trim_galore --version | grep -Eo "[0-9]+(\.[0-9]+)+":
+          type: eval
+          description: The expression to obtain the version of the tool
+
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - trimgalore:
+          type: string
+          description: The name of the tool
+      - trim_galore --version | grep -Eo "[0-9]+(\.[0-9]+)+":
+          type: eval
+          description: The expression to obtain the version of the tool
+
 authors:
   - "@drpatelh"
   - "@ewels"
@@ -103,3 +126,4 @@ maintainers:
   - "@drpatelh"
   - "@ewels"
   - "@FelixKrueger"
+  - "@vagkaratzas"

--- a/modules/nf-core/trimgalore/tests/main.nf.test
+++ b/modules/nf-core/trimgalore/tests/main.nf.test
@@ -3,81 +3,45 @@ nextflow_process {
     name "Test Process TRIMGALORE"
     script "../main.nf"
     process "TRIMGALORE"
+
     tag "modules"
     tag "modules_nfcore"
     tag "trimgalore"
 
-    test("test_trimgalore_single_end") {
+    test("sarscov2 - fastq - single-end") {
 
         when {
             process {
                 """
-                input[0] = [ [ id:'test', single_end:true ], // meta map
-                    [ file(params.modules_testdata_base_path + "genomics/sarscov2/illumina/fastq/test_1.fastq.gz", checkIfExists: true) ]
+                input[0] = [
+                    [ id:'test', single_end:true ],
+                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true) ]
                 ]
                 """
             }
         }
 
         then {
-            def read_lines = ["@ERR5069949.2151832 NS500628:121:HK3MMAFX2:2:21208:10793:15304/1",
-								"TCATAAACCAAAGCACTCACAGTGTCAACAATTTCAGCAGGACAACGCCGACAAGTTCCGAGGAACATGTCTGGACCTATAGTTTTCATAAGTCTACACACTGAATTGAAATATTCTGGTTCTAGTGTGCCCTTAGTTAGCAATGTGCGT",
-								"AAAAAAEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEAAEEEEAEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEAAEEEEE<EEAAAEEEEEEEEEAAAAEAEEEAEEEEEE<AAAA",
-								"@ERR5069949.576388 NS500628:121:HK3MMAFX2:4:11501:11167:14939/1",
-								"ACTGTTTTCTTTGTAGAAAACATCCGTAATAGGACCTTTGTATTCTGAGGACTTTGTAAGTAAAGCACCGTCTATGC",
-								"AAA6AEEEEEEEEEAEEE/6EEAEEEAEEEEEAEEEEEEEEEEEEEEEEEEEEE<AAEEEEEEEEEEE</EEEA/AE"]
-            def report1_lines = ["1	19	25.0	0	19",
-                                    "2	10	6.2	0	10",
-                                    "3	1	1.6	0	1"]
-            assertAll(
-                { assert process.success },
-                { read_lines.each { read_line ->
-                    { assert path(process.out.reads.get(0).get(1)).linesGzip.contains(read_line) }
-                    }
-                },
-                { report1_lines.each { report1_line ->
-                    { assert path(process.out.log.get(0).get(1)).getText().contains(report1_line) }
-                    }
-                },
-                { assert snapshot(path(process.out.versions.get(0)).yaml).match() },
-            )
-        }
-    }
-
-    test("test_trimgalore_single_end - stub") {
-
-    options "-stub"
-
-        when {
-            process {
-                """
-                input[0] = [ [ id:'test', single_end:true ], // meta map
-                    [ file(params.modules_testdata_base_path + "genomics/sarscov2/illumina/fastq/test_1.fastq.gz", checkIfExists: true) ]
-                ]
-                """
-            }
-        }
-
-        then {
-            assertAll(
+            assertAll (
                 { assert process.success },
                 { assert snapshot(
-                    process.out,
-                    path(process.out.versions.get(0)).yaml
-                ).match() },
+                    process.out.reads,
+                    path(process.out.log[0][1]).readLines().dropWhile { !it.startsWith("=== Summary") }.join('\n').md5(),
+                    process.out.findAll { key, val -> key.startsWith("versions") }
+                ).match() }
             )
         }
     }
 
-    test("test_trimgalore_paired_end") {
+    test("sarscov2 - fastq - paired-end") {
 
         when {
             process {
                 """
-                input[0] = [ [ id:'test', single_end:false ], // meta map
+                input[0] = [ [ id:'test', single_end:false ],
                     [
-                        file(params.modules_testdata_base_path + "genomics/sarscov2/illumina/fastq/test_1.fastq.gz", checkIfExists: true),
-                        file(params.modules_testdata_base_path + "genomics/sarscov2/illumina/fastq/test_2.fastq.gz", checkIfExists: true)
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
                     ]
                 ]
                 """
@@ -85,63 +49,33 @@ nextflow_process {
         }
 
         then {
-            def read1_lines = ["@ERR5069949.2151832 NS500628:121:HK3MMAFX2:2:21208:10793:15304/1",
-									"TCATAAACCAAAGCACTCACAGTGTCAACAATTTCAGCAGGACAACGCCGACAAGTTCCGAGGAACATGTCTGGACCTATAGTTTTCATAAGTCTACACACTGAATTGAAATATTCTGGTTCTAGTGTGCCCTTAGTTAGCAATGTGCGT",
-									"AAAAAAEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEAAEEEEAEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEAAEEEEE<EEAAAEEEEEEEEEAAAAEAEEEAEEEEEE<AAAA",
-									"@ERR5069949.576388 NS500628:121:HK3MMAFX2:4:11501:11167:14939/1",
-									"ACTGTTTTCTTTGTAGAAAACATCCGTAATAGGACCTTTGTATTCTGAGGACTTTGTAAGTAAAGCACCGTCTATGC",
-									"AAA6AEEEEEEEEEAEEE/6EEAEEEAEEEEEAEEEEEEEEEEEEEEEEEEEEE<AAEEEEEEEEEEE</EEEA/AE"]
-            def read2_lines = ["@ERR5069949.2151832 NS500628:121:HK3MMAFX2:2:21208:10793:15304/2",
-									"ATGTGTACATTGGCGACCCTGCTCAATTACCTGCACCACGCACATTGCTAACTAAGGGCACACTAGAACCAGAATATTTCAATTCAGTGTGTAGACTTATGAAAACTATAGGTCCAGACATGTTCCTCGGAACTTGTCGGCGTTGTCCTG",
-									"AAAAAEEEEEEEEEE/EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEAEEEEEEEEEE/EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEAAEEEEEEEAEEEEEAAEEEEEEEEEAAEAAA<<EAAEEEEEEEAAA<<<AE",
-									"@ERR5069949.576388 NS500628:121:HK3MMAFX2:4:11501:11167:14939/2",
-									"GCATAGACGGTGCTTTACTTACAAAGTCCTCAGAATACAAAGGTCCTATTACGGATGTTTTCTACAAAGAAAACAGT",
-									"AAAAA6EEAEEEEEAEEAEEAEEEEEEA6EEEEAEEAEEEEE6EEEEEEAEEEEA///A<<EEEEEEEEEAEEEEEE"]
-            def report1_lines = ["1	19	25.0	0	19",
-                                    "2	10	6.2	0	10",
-                                    "3	1	1.6	0	1"]
-            def report2_lines = ["1	28	25.0	0	28",
-                                    "2	10	6.2	0	10",
-                                    "3	1	1.6	0	1"]
-            assertAll(
+            assertAll (
                 { assert process.success },
-                { read1_lines.each { read1_line ->
-                    { assert path(process.out.reads.get(0).get(1).get(0)).linesGzip.contains(read1_line) }
-                    }
-                },
-                { read2_lines.each { read2_line ->
-                    { assert path(process.out.reads.get(0).get(1).get(1)).linesGzip.contains(read2_line) }
-                    }
-                },
-                { report1_lines.each { report1_line ->
-                    { assert path(process.out.log.get(0).get(1).get(0)).getText().contains(report1_line) }
-                    }
-                },
-                { report2_lines.each { report2_line ->
-                    { assert path(process.out.log.get(0).get(1).get(1)).getText().contains(report2_line) }
-                    }
-                },
-                { assert snapshot(path(process.out.versions.get(0)).yaml).match() },
+                { assert snapshot(
+                    process.out.reads,
+                    path(process.out.log[0][1][0]).readLines().dropWhile { !it.startsWith("=== Summary") }.join('\n').md5(),
+                    path(process.out.log[0][1][1]).readLines().dropWhile { !it.startsWith("=== Summary") }.join('\n').md5(),
+                    process.out.findAll { key, val -> key.startsWith("versions") }
+                ).match() }
             )
         }
     }
 
-    test("test_trimgalore_paired_end_keep_unpaired") {
+    test("sarscov2 - fastq - paired-end - keep-unpaired") {
 
         config "./nextflow.config"
 
         when {
-
             params {
                 module_args = '--retain_unpaired --length 150'
             }
 
             process {
                 """
-                input[0] = [ [ id:'test', single_end:false ], // meta map
+                input[0] = [ [ id:'test', single_end:false ],
                     [
-                        file(params.modules_testdata_base_path + "genomics/sarscov2/illumina/fastq/test_1.fastq.gz", checkIfExists: true),
-                        file(params.modules_testdata_base_path + "genomics/sarscov2/illumina/fastq/test_2.fastq.gz", checkIfExists: true)
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
                     ]
                 ]
                 """
@@ -149,28 +83,57 @@ nextflow_process {
         }
 
         then {
-            assertAll(
+            assertAll (
                 { assert process.success },
                 { assert snapshot(
-                    path(process.out.versions.get(0)).yaml,
                     process.out.reads,
-                    process.out.unpaired
-                ).match() },
+                    process.out.unpaired,
+                    path(process.out.log[0][1][0]).readLines().dropWhile { !it.startsWith("=== Summary") }.join('\n').md5(),
+                    path(process.out.log[0][1][1]).readLines().dropWhile { !it.startsWith("=== Summary") }.join('\n').md5(),
+                    process.out.findAll { key, val -> key.startsWith("versions") }
+                ).match() }
             )
         }
     }
 
-    test("test_trimgalore_paired_end - stub") {
+    test("sarscov2 - fastq - single-end - stub") {
 
-    options "-stub"
+        options "-stub"
 
         when {
             process {
                 """
-                input[0] = [ [ id:'test', single_end:false ], // meta map
+                input[0] = [
+                    [ id:'test', single_end:true ],
+                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true) ]
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll (
+                { assert process.success },
+                { assert snapshot(
+                    process.out.reads,
+                    process.out.log,
+                    process.out.findAll { key, val -> key.startsWith("versions") }
+                ).match() }
+            )
+        }
+    }
+
+    test("sarscov2 - fastq - paired-end - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [ [ id:'test', single_end:false ],
                     [
-                        file(params.modules_testdata_base_path + "genomics/sarscov2/illumina/fastq/test_1.fastq.gz", checkIfExists: true),
-                        file(params.modules_testdata_base_path + "genomics/sarscov2/illumina/fastq/test_2.fastq.gz", checkIfExists: true)
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
                     ]
                 ]
                 """
@@ -178,10 +141,13 @@ nextflow_process {
         }
 
         then {
-            assertAll(
+            assertAll (
                 { assert process.success },
-                { assert snapshot(process.out).match() },
-                { assert snapshot(path(process.out.versions.get(0)).yaml).match("versions") },
+                { assert snapshot(
+                    process.out.reads,
+                    process.out.log,
+                    process.out.findAll { key, val -> key.startsWith("versions") }
+                ).match() }
             )
         }
     }

--- a/modules/nf-core/trimgalore/tests/main.nf.test.snap
+++ b/modules/nf-core/trimgalore/tests/main.nf.test.snap
@@ -1,222 +1,48 @@
 {
-    "test_trimgalore_single_end": {
+    "sarscov2 - fastq - paired-end - stub": {
         "content": [
-            {
-                "TRIMGALORE": {
-                    "trimgalore": "0.6.10",
-                    "cutadapt": 4.9,
-                    "pigz": 2.8
-                }
-            }
-        ],
-        "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.3"
-        },
-        "timestamp": "2025-01-06T12:25:01.330769598"
-    },
-    "test_trimgalore_single_end - stub": {
-        "content": [
-            {
-                "0": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
                     [
-                        {
-                            "id": "test",
-                            "single_end": true
-                        },
-                        "test_trimmed.fq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                        "test_1_trimmed.fq.gz:md5,68b329da9893e34099c7d8ad5cb9c940",
+                        "test_2_trimmed.fq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
                     ]
-                ],
-                "1": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": true
-                        },
-                        "test.fastq.gz_trimming_report.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "2": [
-                    
-                ],
-                "3": [
-                    
-                ],
-                "4": [
-                    
-                ],
-                "5": [
-                    "versions.yml:md5,5928323d579768de37e83c56c821757f"
-                ],
-                "html": [
-                    
-                ],
-                "log": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": true
-                        },
-                        "test.fastq.gz_trimming_report.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "reads": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": true
-                        },
-                        "test_trimmed.fq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
-                    ]
-                ],
-                "unpaired": [
-                    
-                ],
-                "versions": [
-                    "versions.yml:md5,5928323d579768de37e83c56c821757f"
-                ],
-                "zip": [
-                    
                 ]
-            },
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    [
+                        "test_1.fastq.gz_trimming_report.txt:md5,d41d8cd98f00b204e9800998ecf8427e",
+                        "test_2.fastq.gz_trimming_report.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ]
+            ],
             {
-                "TRIMGALORE": {
-                    "trimgalore": "0.6.10",
-                    "cutadapt": 4.9,
-                    "pigz": 2.8
-                }
-            }
-        ],
-        "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.3"
-        },
-        "timestamp": "2025-01-06T12:25:15.582246999"
-    },
-    "test_trimgalore_paired_end - stub": {
-        "content": [
-            {
-                "0": [
+                "versions_trimgalore": [
                     [
-                        {
-                            "id": "test",
-                            "single_end": false
-                        },
-                        [
-                            "test_1_trimmed.fq.gz:md5,68b329da9893e34099c7d8ad5cb9c940",
-                            "test_2_trimmed.fq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
-                        ]
+                        "TRIMGALORE",
+                        "trimgalore",
+                        "2.3.0"
                     ]
-                ],
-                "1": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": false
-                        },
-                        [
-                            "test_1.fastq.gz_trimming_report.txt:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "test_2.fastq.gz_trimming_report.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
-                        ]
-                    ]
-                ],
-                "2": [
-                    
-                ],
-                "3": [
-                    
-                ],
-                "4": [
-                    
-                ],
-                "5": [
-                    "versions.yml:md5,5928323d579768de37e83c56c821757f"
-                ],
-                "html": [
-                    
-                ],
-                "log": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": false
-                        },
-                        [
-                            "test_1.fastq.gz_trimming_report.txt:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "test_2.fastq.gz_trimming_report.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
-                        ]
-                    ]
-                ],
-                "reads": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": false
-                        },
-                        [
-                            "test_1_trimmed.fq.gz:md5,68b329da9893e34099c7d8ad5cb9c940",
-                            "test_2_trimmed.fq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
-                        ]
-                    ]
-                ],
-                "unpaired": [
-                    
-                ],
-                "versions": [
-                    "versions.yml:md5,5928323d579768de37e83c56c821757f"
-                ],
-                "zip": [
-                    
                 ]
             }
         ],
+        "timestamp": "2026-05-05T08:48:10.832490464",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.3"
-        },
-        "timestamp": "2025-01-06T12:26:05.201562315"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.0"
+        }
     },
-    "versions": {
+    "sarscov2 - fastq - paired-end - keep-unpaired": {
         "content": [
-            {
-                "TRIMGALORE": {
-                    "trimgalore": "0.6.10",
-                    "cutadapt": 4.9,
-                    "pigz": 2.8
-                }
-            }
-        ],
-        "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.3"
-        },
-        "timestamp": "2025-01-06T12:26:05.229598492"
-    },
-    "test_trimgalore_paired_end": {
-        "content": [
-            {
-                "TRIMGALORE": {
-                    "trimgalore": "0.6.10",
-                    "cutadapt": 4.9,
-                    "pigz": 2.8
-                }
-            }
-        ],
-        "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.3"
-        },
-        "timestamp": "2025-01-06T12:25:33.510924538"
-    },
-    "test_trimgalore_paired_end_keep_unpaired": {
-        "content": [
-            {
-                "TRIMGALORE": {
-                    "trimgalore": "0.6.10",
-                    "cutadapt": 4.9,
-                    "pigz": 2.8
-                }
-            },
             [
                 [
                     {
@@ -240,12 +66,119 @@
                         "test_2_unpaired_2.fq.gz:md5,b09a064368a867e099e66df5ef69b044"
                     ]
                 ]
-            ]
+            ],
+            "4cbef464fbc09252a1282078ec23942e",
+            "ee1b8a371f1490e5faf5e346523b8886",
+            {
+                "versions_trimgalore": [
+                    [
+                        "TRIMGALORE",
+                        "trimgalore",
+                        "2.3.0"
+                    ]
+                ]
+            }
         ],
+        "timestamp": "2026-05-05T09:34:57.668635539",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.3"
-        },
-        "timestamp": "2025-01-06T12:25:46.461002981"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.0"
+        }
+    },
+    "sarscov2 - fastq - single-end - stub": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true
+                    },
+                    "test_trimmed.fq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true
+                    },
+                    "test.fastq.gz_trimming_report.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                ]
+            ],
+            {
+                "versions_trimgalore": [
+                    [
+                        "TRIMGALORE",
+                        "trimgalore",
+                        "2.3.0"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-05-05T08:48:05.803691794",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.0"
+        }
+    },
+    "sarscov2 - fastq - paired-end": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    [
+                        "test_1_val_1.fq.gz:md5,566d44cca0d22c522d6cf0e50c7165dc",
+                        "test_2_val_2.fq.gz:md5,3c023e8e890b897821df3dc98f48c2b3"
+                    ]
+                ]
+            ],
+            "4da0165f1c5a0d3f1d5eea9ad17fb1fb",
+            "808929d2f70ffea0ddd7750bbb400b02",
+            {
+                "versions_trimgalore": [
+                    [
+                        "TRIMGALORE",
+                        "trimgalore",
+                        "2.3.0"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-05-05T09:34:52.551563029",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.0"
+        }
+    },
+    "sarscov2 - fastq - single-end": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true
+                    },
+                    "test_trimmed.fq.gz:md5,566d44cca0d22c522d6cf0e50c7165dc"
+                ]
+            ],
+            "76dd6b9d009e332d2aa6443de525c182",
+            {
+                "versions_trimgalore": [
+                    [
+                        "TRIMGALORE",
+                        "trimgalore",
+                        "2.3.0"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-05-05T09:34:47.273738299",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.0"
+        }
     }
 }

--- a/tests/bismark_hisat_variants.nf.test.snap
+++ b/tests/bismark_hisat_variants.nf.test.snap
@@ -2,11 +2,6 @@
     "Params: bismark_hisat with rrbs": {
         "content": [
             {
-                "TRIMGALORE": {
-                    "trimgalore": "0.6.10",
-                    "cutadapt": 4.9,
-                    "pigz": 2.8
-                },
                 "Workflow": {
                     "nf-core/methylseq": "v4.3.0dev"
                 },
@@ -39,6 +34,9 @@
                 },
                 "SAMTOOLS_SORT": {
                     "samtools": "1.23.1"
+                },
+                "TRIMGALORE": {
+                    "trimgalore": "2.3.0"
                 }
             },
             [
@@ -338,7 +336,7 @@
                 "multiqc_bismark_alignment.txt:md5,3a53587ae3dbd351028bcc783f1403c4",
                 "multiqc_bismark_methextract.txt:md5,49c773a9e0f10291974cf55ea095208c",
                 "multiqc_citations.txt:md5,73a6d29705d5a07f17f99c92e3a0f148",
-                "multiqc_cutadapt.txt:md5,8752cce2e7320f49516e897c60487831"
+                "multiqc_cutadapt.txt:md5,7ea4af4e9cecb17dd264d60d5975b6ac"
             ],
             [
                 [
@@ -375,20 +373,15 @@
                 ]
             ]
         ],
-        "timestamp": "2026-07-10T14:52:55.429983261",
+        "timestamp": "2026-07-18T18:15:23.007060472",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.04.0"
+            "nextflow": "26.04.3"
         }
     },
     "Params: bismark_hisat with save_reference and save_align_intermeds": {
         "content": [
             {
-                "TRIMGALORE": {
-                    "trimgalore": "0.6.10",
-                    "cutadapt": 4.9,
-                    "pigz": 2.8
-                },
                 "Workflow": {
                     "nf-core/methylseq": "v4.3.0dev"
                 },
@@ -424,6 +417,9 @@
                 },
                 "SAMTOOLS_SORT": {
                     "samtools": "1.23.1"
+                },
+                "TRIMGALORE": {
+                    "trimgalore": "2.3.0"
                 }
             },
             [
@@ -782,7 +778,7 @@
                 "multiqc_bismark_dedup.txt:md5,5e58032548eda3c39384495cf0cfaa3d",
                 "multiqc_bismark_methextract.txt:md5,208b2ab329054fb8c664831747573fbb",
                 "multiqc_citations.txt:md5,73a6d29705d5a07f17f99c92e3a0f148",
-                "multiqc_cutadapt.txt:md5,883891ac4901385102be053212068732"
+                "multiqc_cutadapt.txt:md5,7ea4af4e9cecb17dd264d60d5975b6ac"
             ],
             [
                 [
@@ -819,20 +815,15 @@
                 ]
             ]
         ],
-        "timestamp": "2026-07-10T14:53:37.903546677",
+        "timestamp": "2026-07-18T18:16:03.01345335",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.04.0"
+            "nextflow": "26.04.3"
         }
     },
     "Params: bismark_hisat": {
         "content": [
             {
-                "TRIMGALORE": {
-                    "trimgalore": "0.6.10",
-                    "cutadapt": 4.9,
-                    "pigz": 2.8
-                },
                 "Workflow": {
                     "nf-core/methylseq": "v4.3.0dev"
                 },
@@ -868,6 +859,9 @@
                 },
                 "SAMTOOLS_SORT": {
                     "samtools": "1.23.1"
+                },
+                "TRIMGALORE": {
+                    "trimgalore": "2.3.0"
                 }
             },
             [
@@ -1179,7 +1173,7 @@
                 "multiqc_bismark_dedup.txt:md5,5e58032548eda3c39384495cf0cfaa3d",
                 "multiqc_bismark_methextract.txt:md5,208b2ab329054fb8c664831747573fbb",
                 "multiqc_citations.txt:md5,73a6d29705d5a07f17f99c92e3a0f148",
-                "multiqc_cutadapt.txt:md5,883891ac4901385102be053212068732"
+                "multiqc_cutadapt.txt:md5,7ea4af4e9cecb17dd264d60d5975b6ac"
             ],
             [
                 [
@@ -1200,10 +1194,10 @@
                 ]
             ]
         ],
-        "timestamp": "2026-07-10T14:52:13.497844254",
+        "timestamp": "2026-07-18T18:14:45.826117518",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.04.0"
+            "nextflow": "26.04.3"
         }
     }
 }

--- a/tests/bismark_variants.nf.test.snap
+++ b/tests/bismark_variants.nf.test.snap
@@ -5,11 +5,6 @@
                 "QUALIMAP_BAMQC": {
                     "qualimap": 2.3
                 },
-                "TRIMGALORE": {
-                    "trimgalore": "0.6.10",
-                    "cutadapt": 4.9,
-                    "pigz": 2.8
-                },
                 "Workflow": {
                     "nf-core/methylseq": "v4.3.0dev"
                 },
@@ -45,6 +40,9 @@
                 },
                 "SAMTOOLS_SORT": {
                     "samtools": "1.23.1"
+                },
+                "TRIMGALORE": {
+                    "trimgalore": "2.3.0"
                 }
             },
             [
@@ -606,7 +604,7 @@
                 "multiqc_bismark_dedup.txt:md5,d09a5de4d81a3207efb6a8937d060e46",
                 "multiqc_bismark_methextract.txt:md5,4b6db3a59616df1c803713affc07e043",
                 "multiqc_citations.txt:md5,b9d42869faad581bd963d3d3bb490026",
-                "multiqc_cutadapt.txt:md5,883891ac4901385102be053212068732",
+                "multiqc_cutadapt.txt:md5,7ea4af4e9cecb17dd264d60d5975b6ac",
                 "qualimap_coverage_histogram.txt:md5,7cd194077fe839edf034b44cc73dd024",
                 "qualimap_gc_content.txt:md5,4f6ec70d9fb71ffe5f2f99f44fe5ef0c",
                 "qualimap_genome_fraction.txt:md5,3e528946a376ae752b57adaaa73f5cdf",
@@ -631,20 +629,15 @@
                 ]
             ]
         ],
-        "timestamp": "2026-07-10T15:00:47.970440164",
+        "timestamp": "2026-07-18T18:23:32.717768947",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.04.0"
+            "nextflow": "26.04.3"
         }
     },
     "Params: bismark with nomeseq": {
         "content": [
             {
-                "TRIMGALORE": {
-                    "trimgalore": "0.6.10",
-                    "cutadapt": 4.9,
-                    "pigz": 2.8
-                },
                 "Workflow": {
                     "nf-core/methylseq": "v4.3.0dev"
                 },
@@ -683,6 +676,9 @@
                 },
                 "SAMTOOLS_SORT": {
                     "samtools": "1.23.1"
+                },
+                "TRIMGALORE": {
+                    "trimgalore": "2.3.0"
                 }
             },
             [
@@ -1038,7 +1034,7 @@
                 "multiqc_bismark_dedup.txt:md5,d09a5de4d81a3207efb6a8937d060e46",
                 "multiqc_bismark_methextract.txt:md5,4b6db3a59616df1c803713affc07e043",
                 "multiqc_citations.txt:md5,73a6d29705d5a07f17f99c92e3a0f148",
-                "multiqc_cutadapt.txt:md5,883891ac4901385102be053212068732"
+                "multiqc_cutadapt.txt:md5,7ea4af4e9cecb17dd264d60d5975b6ac"
             ],
             [
                 [
@@ -1059,20 +1055,15 @@
                 ]
             ]
         ],
-        "timestamp": "2026-07-10T14:58:32.15805515",
+        "timestamp": "2026-07-18T18:20:30.242121848",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.04.0"
+            "nextflow": "26.04.3"
         }
     },
     "Params: bismark with skip_multiqc": {
         "content": [
             {
-                "TRIMGALORE": {
-                    "trimgalore": "0.6.10",
-                    "cutadapt": 4.9,
-                    "pigz": 2.8
-                },
                 "Workflow": {
                     "nf-core/methylseq": "v4.3.0dev"
                 },
@@ -1105,6 +1096,9 @@
                 },
                 "SAMTOOLS_SORT": {
                     "samtools": "1.23.1"
+                },
+                "TRIMGALORE": {
+                    "trimgalore": "2.3.0"
                 }
             },
             [
@@ -1279,20 +1273,15 @@
                 ]
             ]
         ],
-        "timestamp": "2026-07-10T15:01:19.843600418",
+        "timestamp": "2026-07-18T18:24:03.739774052",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.04.0"
+            "nextflow": "26.04.3"
         }
     },
     "Params: bismark (default)": {
         "content": [
             {
-                "TRIMGALORE": {
-                    "trimgalore": "0.6.10",
-                    "cutadapt": 4.9,
-                    "pigz": 2.8
-                },
                 "Workflow": {
                     "nf-core/methylseq": "v4.3.0dev"
                 },
@@ -1328,6 +1317,9 @@
                 },
                 "SAMTOOLS_SORT": {
                     "samtools": "1.23.1"
+                },
+                "TRIMGALORE": {
+                    "trimgalore": "2.3.0"
                 }
             },
             [
@@ -1639,7 +1631,7 @@
                 "multiqc_bismark_dedup.txt:md5,d09a5de4d81a3207efb6a8937d060e46",
                 "multiqc_bismark_methextract.txt:md5,4b6db3a59616df1c803713affc07e043",
                 "multiqc_citations.txt:md5,73a6d29705d5a07f17f99c92e3a0f148",
-                "multiqc_cutadapt.txt:md5,883891ac4901385102be053212068732"
+                "multiqc_cutadapt.txt:md5,7ea4af4e9cecb17dd264d60d5975b6ac"
             ],
             [
                 [
@@ -1660,20 +1652,15 @@
                 ]
             ]
         ],
-        "timestamp": "2026-07-10T14:54:20.004907724",
+        "timestamp": "2026-07-18T18:16:41.439460113",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.04.0"
+            "nextflow": "26.04.3"
         }
     },
     "Params: bismark with cytosine_report": {
         "content": [
             {
-                "TRIMGALORE": {
-                    "trimgalore": "0.6.10",
-                    "cutadapt": 4.9,
-                    "pigz": 2.8
-                },
                 "Workflow": {
                     "nf-core/methylseq": "v4.3.0dev"
                 },
@@ -1712,6 +1699,9 @@
                 },
                 "SAMTOOLS_SORT": {
                     "samtools": "1.23.1"
+                },
+                "TRIMGALORE": {
+                    "trimgalore": "2.3.0"
                 }
             },
             [
@@ -2043,7 +2033,7 @@
                 "multiqc_bismark_dedup.txt:md5,d09a5de4d81a3207efb6a8937d060e46",
                 "multiqc_bismark_methextract.txt:md5,4b6db3a59616df1c803713affc07e043",
                 "multiqc_citations.txt:md5,73a6d29705d5a07f17f99c92e3a0f148",
-                "multiqc_cutadapt.txt:md5,883891ac4901385102be053212068732"
+                "multiqc_cutadapt.txt:md5,7ea4af4e9cecb17dd264d60d5975b6ac"
             ],
             [
                 [
@@ -2064,20 +2054,15 @@
                 ]
             ]
         ],
-        "timestamp": "2026-07-10T14:56:19.42864735",
+        "timestamp": "2026-07-18T18:18:32.501033786",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.04.0"
+            "nextflow": "26.04.3"
         }
     },
     "Params: bismark with em_seq and clip_r1": {
         "content": [
             {
-                "TRIMGALORE": {
-                    "trimgalore": "0.6.10",
-                    "cutadapt": 4.9,
-                    "pigz": 2.8
-                },
                 "Workflow": {
                     "nf-core/methylseq": "v4.3.0dev"
                 },
@@ -2113,6 +2098,9 @@
                 },
                 "SAMTOOLS_SORT": {
                     "samtools": "1.23.1"
+                },
+                "TRIMGALORE": {
+                    "trimgalore": "2.3.0"
                 }
             },
             [
@@ -2424,7 +2412,7 @@
                 "multiqc_bismark_dedup.txt:md5,16e464f5bf2f1851a571ec87cbc1a0d9",
                 "multiqc_bismark_methextract.txt:md5,7706d3d9e4490eeb449d14dce92ada68",
                 "multiqc_citations.txt:md5,73a6d29705d5a07f17f99c92e3a0f148",
-                "multiqc_cutadapt.txt:md5,883891ac4901385102be053212068732"
+                "multiqc_cutadapt.txt:md5,7ea4af4e9cecb17dd264d60d5975b6ac"
             ],
             [
                 [
@@ -2445,10 +2433,10 @@
                 ]
             ]
         ],
-        "timestamp": "2026-07-10T14:57:48.176679354",
+        "timestamp": "2026-07-18T18:19:48.116274419",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.04.0"
+            "nextflow": "26.04.3"
         }
     },
     "Params: bismark with skip_trimming": {
@@ -2791,11 +2779,6 @@
     "Params: bismark with skip_deduplication": {
         "content": [
             {
-                "TRIMGALORE": {
-                    "trimgalore": "0.6.10",
-                    "cutadapt": 4.9,
-                    "pigz": 2.8
-                },
                 "Workflow": {
                     "nf-core/methylseq": "v4.3.0dev"
                 },
@@ -2828,6 +2811,9 @@
                 },
                 "SAMTOOLS_SORT": {
                     "samtools": "1.23.1"
+                },
+                "TRIMGALORE": {
+                    "trimgalore": "2.3.0"
                 }
             },
             [
@@ -3127,7 +3113,7 @@
                 "multiqc_bismark_alignment.txt:md5,8ee2e88d6b5c1411b4665b02f82ae1b7",
                 "multiqc_bismark_methextract.txt:md5,59ae6807dd32e01f9793335997217b0a",
                 "multiqc_citations.txt:md5,73a6d29705d5a07f17f99c92e3a0f148",
-                "multiqc_cutadapt.txt:md5,883891ac4901385102be053212068732"
+                "multiqc_cutadapt.txt:md5,7ea4af4e9cecb17dd264d60d5975b6ac"
             ],
             [
                 [
@@ -3164,20 +3150,15 @@
                 ]
             ]
         ],
-        "timestamp": "2026-07-10T14:55:37.262992414",
+        "timestamp": "2026-07-18T18:17:52.528548034",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.04.0"
+            "nextflow": "26.04.3"
         }
     },
     "Params: bismark with rrbs": {
         "content": [
             {
-                "TRIMGALORE": {
-                    "trimgalore": "0.6.10",
-                    "cutadapt": 4.9,
-                    "pigz": 2.8
-                },
                 "Workflow": {
                     "nf-core/methylseq": "v4.3.0dev"
                 },
@@ -3210,6 +3191,9 @@
                 },
                 "SAMTOOLS_SORT": {
                     "samtools": "1.23.1"
+                },
+                "TRIMGALORE": {
+                    "trimgalore": "2.3.0"
                 }
             },
             [
@@ -3509,7 +3493,7 @@
                 "multiqc_bismark_alignment.txt:md5,715120445eec068fb944e5458bbe45a9",
                 "multiqc_bismark_methextract.txt:md5,a29d6abb8cd7e56180fd9553d5019e2d",
                 "multiqc_citations.txt:md5,73a6d29705d5a07f17f99c92e3a0f148",
-                "multiqc_cutadapt.txt:md5,8752cce2e7320f49516e897c60487831"
+                "multiqc_cutadapt.txt:md5,7ea4af4e9cecb17dd264d60d5975b6ac"
             ],
             [
                 [
@@ -3546,20 +3530,15 @@
                 ]
             ]
         ],
-        "timestamp": "2026-07-10T14:57:02.780338451",
+        "timestamp": "2026-07-18T18:19:08.75082939",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.04.0"
+            "nextflow": "26.04.3"
         }
     },
     "Params: bismark with save_reference and save_align_intermeds": {
         "content": [
             {
-                "TRIMGALORE": {
-                    "trimgalore": "0.6.10",
-                    "cutadapt": 4.9,
-                    "pigz": 2.8
-                },
                 "Workflow": {
                     "nf-core/methylseq": "v4.3.0dev"
                 },
@@ -3595,6 +3574,9 @@
                 },
                 "SAMTOOLS_SORT": {
                     "samtools": "1.23.1"
+                },
+                "TRIMGALORE": {
+                    "trimgalore": "2.3.0"
                 }
             },
             [
@@ -3945,7 +3927,7 @@
                 "multiqc_bismark_dedup.txt:md5,d09a5de4d81a3207efb6a8937d060e46",
                 "multiqc_bismark_methextract.txt:md5,4b6db3a59616df1c803713affc07e043",
                 "multiqc_citations.txt:md5,73a6d29705d5a07f17f99c92e3a0f148",
-                "multiqc_cutadapt.txt:md5,883891ac4901385102be053212068732"
+                "multiqc_cutadapt.txt:md5,7ea4af4e9cecb17dd264d60d5975b6ac"
             ],
             [
                 [
@@ -3982,10 +3964,10 @@
                 ]
             ]
         ],
-        "timestamp": "2026-07-10T14:59:15.817696372",
+        "timestamp": "2026-07-18T18:21:12.041359243",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.04.0"
+            "nextflow": "26.04.3"
         }
     },
     "Params: bismark with CAT_FASTQ and skip_trimming and skip_deduplication": {
@@ -4265,11 +4247,6 @@
     "Params: bismark with run_preseq": {
         "content": [
             {
-                "TRIMGALORE": {
-                    "trimgalore": "0.6.10",
-                    "cutadapt": 4.9,
-                    "pigz": 2.8
-                },
                 "Workflow": {
                     "nf-core/methylseq": "v4.3.0dev"
                 },
@@ -4305,6 +4282,9 @@
                 },
                 "SAMTOOLS_SORT": {
                     "samtools": "1.23.1"
+                },
+                "TRIMGALORE": {
+                    "trimgalore": "2.3.0"
                 }
             },
             [
@@ -4616,7 +4596,7 @@
                 "multiqc_bismark_dedup.txt:md5,d09a5de4d81a3207efb6a8937d060e46",
                 "multiqc_bismark_methextract.txt:md5,4b6db3a59616df1c803713affc07e043",
                 "multiqc_citations.txt:md5,73a6d29705d5a07f17f99c92e3a0f148",
-                "multiqc_cutadapt.txt:md5,883891ac4901385102be053212068732"
+                "multiqc_cutadapt.txt:md5,7ea4af4e9cecb17dd264d60d5975b6ac"
             ],
             [
                 [
@@ -4637,20 +4617,15 @@
                 ]
             ]
         ],
-        "timestamp": "2026-07-10T14:59:59.915051953",
+        "timestamp": "2026-07-18T18:21:52.318927557",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.04.0"
+            "nextflow": "26.04.3"
         }
     },
     "Params: bismark with skip_fastqc": {
         "content": [
             {
-                "TRIMGALORE": {
-                    "trimgalore": "0.6.10",
-                    "cutadapt": 4.9,
-                    "pigz": 2.8
-                },
                 "Workflow": {
                     "nf-core/methylseq": "v4.3.0dev"
                 },
@@ -4683,6 +4658,9 @@
                 },
                 "SAMTOOLS_SORT": {
                     "samtools": "1.23.1"
+                },
+                "TRIMGALORE": {
+                    "trimgalore": "2.3.0"
                 }
             },
             [
@@ -4926,7 +4904,7 @@
                 "multiqc_bismark_dedup.txt:md5,d09a5de4d81a3207efb6a8937d060e46",
                 "multiqc_bismark_methextract.txt:md5,4b6db3a59616df1c803713affc07e043",
                 "multiqc_citations.txt:md5,73a6d29705d5a07f17f99c92e3a0f148",
-                "multiqc_cutadapt.txt:md5,883891ac4901385102be053212068732"
+                "multiqc_cutadapt.txt:md5,7ea4af4e9cecb17dd264d60d5975b6ac"
             ],
             [
                 [
@@ -4947,10 +4925,10 @@
                 ]
             ]
         ],
-        "timestamp": "2026-07-10T15:01:57.017198454",
+        "timestamp": "2026-07-18T18:24:40.560091579",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.04.0"
+            "nextflow": "26.04.3"
         }
     }
 }

--- a/tests/bwamem_taps.nf.test.snap
+++ b/tests/bwamem_taps.nf.test.snap
@@ -14,11 +14,6 @@
                 "RASTAIR_METHYLKIT": {
                     "rastair": "rastair 0.8.2"
                 },
-                "TRIMGALORE": {
-                    "trimgalore": "0.6.10",
-                    "cutadapt": 4.9,
-                    "pigz": 2.8
-                },
                 "Workflow": {
                     "nf-core/methylseq": "v4.3.0dev"
                 },
@@ -57,6 +52,9 @@
                 },
                 "SAMTOOLS_STATS": {
                     "samtools": "1.23.1"
+                },
+                "TRIMGALORE": {
+                    "trimgalore": "2.3.0"
                 }
             },
             [
@@ -261,7 +259,7 @@
                 "fastqc_sequence_duplication_levels_plot.txt:md5,9e5712db9aa39b5754ea1e0c49cfff15",
                 "fastqc_top_overrepresented_sequences_table.txt:md5,6dfc5334a09c05392ea17369aa742d01",
                 "multiqc_citations.txt:md5,78cc0f4521878c6c4beaf54ad968e411",
-                "multiqc_cutadapt.txt:md5,883891ac4901385102be053212068732",
+                "multiqc_cutadapt.txt:md5,7ea4af4e9cecb17dd264d60d5975b6ac",
                 "multiqc_picard_dups.txt:md5,d55cf05658f0502ffbe45fa497627b73",
                 "picard_MarkIlluminaAdapters_histogram.txt:md5,d41d8cd98f00b204e9800998ecf8427e",
                 "picard_MeanQualityByCycle_histogram.txt:md5,d41d8cd98f00b204e9800998ecf8427e",
@@ -304,10 +302,10 @@
                 ]
             ]
         ],
-        "timestamp": "2026-07-10T15:03:38.755690653",
+        "timestamp": "2026-07-18T18:27:13.287705067",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.04.0"
+            "nextflow": "26.04.3"
         }
     }
 }

--- a/tests/bwameth_use_gpu.nf.test.snap
+++ b/tests/bwameth_use_gpu.nf.test.snap
@@ -2,11 +2,6 @@
     "Params: PARABRICKS_FQ2BAMMETH - GPU Profile": {
         "content": [
             {
-                "TRIMGALORE": {
-                    "trimgalore": "0.6.10",
-                    "cutadapt": 4.9,
-                    "pigz": 2.8
-                },
                 "Workflow": {
                     "nf-core/methylseq": "v4.3.0dev"
                 },
@@ -48,6 +43,9 @@
                 },
                 "SAMTOOLS_STATS": {
                     "samtools": "1.23.1"
+                },
+                "TRIMGALORE": {
+                    "trimgalore": "2.3.0"
                 }
             },
             [
@@ -229,7 +227,7 @@
                 "fastqc_sequence_duplication_levels_plot.txt:md5,b86ac1b21d5f9adb7875640ddef95b5a",
                 "fastqc_top_overrepresented_sequences_table.txt:md5,36b233534f727b98041df8c987e05b9e",
                 "multiqc_citations.txt:md5,ad6c1e326b4276501a3b42eaad747de1",
-                "multiqc_cutadapt.txt:md5,8562f9a4488d847dd6457a95b983b808",
+                "multiqc_cutadapt.txt:md5,51b7d662dd00b4bc2cac5252ff14632e",
                 "multiqc_samtools_flagstat.txt:md5,082795eb003adb27217832b56fbda0d3",
                 "multiqc_samtools_stats.txt:md5,8ce3aebd6baaf0d197db5a517f9f5671",
                 "picard_MarkIlluminaAdapters_histogram.txt:md5,d41d8cd98f00b204e9800998ecf8427e",
@@ -256,10 +254,10 @@
                 ]
             ]
         ],
+        "timestamp": "2026-07-18T18:59:22.952768805",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.04.0"
-        },
-        "timestamp": "2026-07-10T15:57:55.32124461"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.3"
+        }
     }
 }

--- a/tests/bwameth_variants.nf.test.snap
+++ b/tests/bwameth_variants.nf.test.snap
@@ -5,11 +5,6 @@
                 "QUALIMAP_BAMQC": {
                     "qualimap": 2.3
                 },
-                "TRIMGALORE": {
-                    "trimgalore": "0.6.10",
-                    "cutadapt": 4.9,
-                    "pigz": 2.8
-                },
                 "Workflow": {
                     "nf-core/methylseq": "v4.3.0dev"
                 },
@@ -51,6 +46,9 @@
                 },
                 "SAMTOOLS_STATS": {
                     "samtools": "1.23.1"
+                },
+                "TRIMGALORE": {
+                    "trimgalore": "2.3.0"
                 }
             },
             [
@@ -441,7 +439,7 @@
                 "fastqc_sequence_duplication_levels_plot.txt:md5,9e5712db9aa39b5754ea1e0c49cfff15",
                 "fastqc_top_overrepresented_sequences_table.txt:md5,6dfc5334a09c05392ea17369aa742d01",
                 "multiqc_citations.txt:md5,581df5b266851d0244e7cfb213351ffb",
-                "multiqc_cutadapt.txt:md5,883891ac4901385102be053212068732",
+                "multiqc_cutadapt.txt:md5,7ea4af4e9cecb17dd264d60d5975b6ac",
                 "multiqc_picard_dups.txt:md5,82eaab96189f22fd93db38bb516ba6a5",
                 "multiqc_samtools_flagstat.txt:md5,a8f5b45b8b3412a9adc3dd0d35208c73",
                 "multiqc_samtools_stats.txt:md5,edac97e95c57ea6276d3b3801ed732a8",
@@ -478,20 +476,15 @@
                 ]
             ]
         ],
-        "timestamp": "2026-07-10T15:09:11.060362889",
+        "timestamp": "2026-07-18T18:32:08.56512282",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.04.0"
+            "nextflow": "26.04.3"
         }
     },
     "Params: bwameth with skip_deduplication": {
         "content": [
             {
-                "TRIMGALORE": {
-                    "trimgalore": "0.6.10",
-                    "cutadapt": 4.9,
-                    "pigz": 2.8
-                },
                 "Workflow": {
                     "nf-core/methylseq": "v4.3.0dev"
                 },
@@ -527,6 +520,9 @@
                 },
                 "SAMTOOLS_STATS": {
                     "samtools": "1.23.1"
+                },
+                "TRIMGALORE": {
+                    "trimgalore": "2.3.0"
                 }
             },
             [
@@ -724,7 +720,7 @@
                 "fastqc_sequence_duplication_levels_plot.txt:md5,9e5712db9aa39b5754ea1e0c49cfff15",
                 "fastqc_top_overrepresented_sequences_table.txt:md5,6dfc5334a09c05392ea17369aa742d01",
                 "multiqc_citations.txt:md5,ad6c1e326b4276501a3b42eaad747de1",
-                "multiqc_cutadapt.txt:md5,883891ac4901385102be053212068732",
+                "multiqc_cutadapt.txt:md5,7ea4af4e9cecb17dd264d60d5975b6ac",
                 "multiqc_samtools_flagstat.txt:md5,a8f5b45b8b3412a9adc3dd0d35208c73",
                 "multiqc_samtools_stats.txt:md5,edac97e95c57ea6276d3b3801ed732a8",
                 "samtools-flagstat-pct-table.txt:md5,ff5d65a480449ba98587c43f3a2bd33e",
@@ -751,20 +747,15 @@
                 ]
             ]
         ],
-        "timestamp": "2026-07-10T15:06:44.353331563",
+        "timestamp": "2026-07-18T18:30:02.638645132",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.04.0"
+            "nextflow": "26.04.3"
         }
     },
     "Params: bwameth with skip_fastqc": {
         "content": [
             {
-                "TRIMGALORE": {
-                    "trimgalore": "0.6.10",
-                    "cutadapt": 4.9,
-                    "pigz": 2.8
-                },
                 "Workflow": {
                     "nf-core/methylseq": "v4.3.0dev"
                 },
@@ -803,6 +794,9 @@
                 },
                 "SAMTOOLS_STATS": {
                     "samtools": "1.23.1"
+                },
+                "TRIMGALORE": {
+                    "trimgalore": "2.3.0"
                 }
             },
             [
@@ -950,7 +944,7 @@
                 "cutadapt_trimmed_sequences_plot_3_Counts.txt:md5,57d07c19b0c30dc88df96c30bedcdc33",
                 "cutadapt_trimmed_sequences_plot_3_Obs_Exp.txt:md5,1e5ca4193f8290c5c812334d03615b41",
                 "multiqc_citations.txt:md5,ad6c1e326b4276501a3b42eaad747de1",
-                "multiqc_cutadapt.txt:md5,883891ac4901385102be053212068732",
+                "multiqc_cutadapt.txt:md5,7ea4af4e9cecb17dd264d60d5975b6ac",
                 "multiqc_picard_dups.txt:md5,82eaab96189f22fd93db38bb516ba6a5",
                 "multiqc_samtools_flagstat.txt:md5,a8f5b45b8b3412a9adc3dd0d35208c73",
                 "multiqc_samtools_stats.txt:md5,edac97e95c57ea6276d3b3801ed732a8",
@@ -983,10 +977,10 @@
                 ]
             ]
         ],
-        "timestamp": "2026-07-10T15:09:52.963755762",
+        "timestamp": "2026-07-18T18:32:44.246815718",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.04.0"
+            "nextflow": "26.04.3"
         }
     },
     "Params: bwameth with CAT_FASTQ and skip_trimming and skip_deduplication": {
@@ -1195,11 +1189,6 @@
     "Params: bwameth": {
         "content": [
             {
-                "TRIMGALORE": {
-                    "trimgalore": "0.6.10",
-                    "cutadapt": 4.9,
-                    "pigz": 2.8
-                },
                 "Workflow": {
                     "nf-core/methylseq": "v4.3.0dev"
                 },
@@ -1241,6 +1230,9 @@
                 },
                 "SAMTOOLS_STATS": {
                     "samtools": "1.23.1"
+                },
+                "TRIMGALORE": {
+                    "trimgalore": "2.3.0"
                 }
             },
             [
@@ -1456,7 +1448,7 @@
                 "fastqc_sequence_duplication_levels_plot.txt:md5,9e5712db9aa39b5754ea1e0c49cfff15",
                 "fastqc_top_overrepresented_sequences_table.txt:md5,6dfc5334a09c05392ea17369aa742d01",
                 "multiqc_citations.txt:md5,ad6c1e326b4276501a3b42eaad747de1",
-                "multiqc_cutadapt.txt:md5,883891ac4901385102be053212068732",
+                "multiqc_cutadapt.txt:md5,7ea4af4e9cecb17dd264d60d5975b6ac",
                 "multiqc_picard_dups.txt:md5,82eaab96189f22fd93db38bb516ba6a5",
                 "multiqc_samtools_flagstat.txt:md5,a8f5b45b8b3412a9adc3dd0d35208c73",
                 "multiqc_samtools_stats.txt:md5,edac97e95c57ea6276d3b3801ed732a8",
@@ -1489,20 +1481,15 @@
                 ]
             ]
         ],
-        "timestamp": "2026-07-10T15:04:26.80540722",
+        "timestamp": "2026-07-18T18:28:05.493698532",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.04.0"
+            "nextflow": "26.04.3"
         }
     },
     "Params: bwameth with skip_multiqc": {
         "content": [
             {
-                "TRIMGALORE": {
-                    "trimgalore": "0.6.10",
-                    "cutadapt": 4.9,
-                    "pigz": 2.8
-                },
                 "Workflow": {
                     "nf-core/methylseq": "v4.3.0dev"
                 },
@@ -1541,6 +1528,9 @@
                 },
                 "SAMTOOLS_STATS": {
                     "samtools": "1.23.1"
+                },
+                "TRIMGALORE": {
+                    "trimgalore": "2.3.0"
                 }
             },
             [
@@ -1651,10 +1641,10 @@
                 ]
             ]
         ],
-        "timestamp": "2026-07-10T15:10:29.747350416",
+        "timestamp": "2026-07-18T18:33:18.536330551",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.04.0"
+            "nextflow": "26.04.3"
         }
     },
     "Params: bwameth with skip_trimming": {
@@ -1919,11 +1909,6 @@
     "Params: bwameth with mem2 index": {
         "content": [
             {
-                "TRIMGALORE": {
-                    "trimgalore": "0.6.10",
-                    "cutadapt": 4.9,
-                    "pigz": 2.8
-                },
                 "Workflow": {
                     "nf-core/methylseq": "v4.3.0dev"
                 },
@@ -1965,6 +1950,9 @@
                 },
                 "SAMTOOLS_STATS": {
                     "samtools": "1.23.1"
+                },
+                "TRIMGALORE": {
+                    "trimgalore": "2.3.0"
                 }
             },
             [
@@ -2180,7 +2168,7 @@
                 "fastqc_sequence_duplication_levels_plot.txt:md5,9e5712db9aa39b5754ea1e0c49cfff15",
                 "fastqc_top_overrepresented_sequences_table.txt:md5,6dfc5334a09c05392ea17369aa742d01",
                 "multiqc_citations.txt:md5,ad6c1e326b4276501a3b42eaad747de1",
-                "multiqc_cutadapt.txt:md5,883891ac4901385102be053212068732",
+                "multiqc_cutadapt.txt:md5,7ea4af4e9cecb17dd264d60d5975b6ac",
                 "multiqc_picard_dups.txt:md5,82eaab96189f22fd93db38bb516ba6a5",
                 "multiqc_samtools_flagstat.txt:md5,a8f5b45b8b3412a9adc3dd0d35208c73",
                 "multiqc_samtools_stats.txt:md5,edac97e95c57ea6276d3b3801ed732a8",
@@ -2213,20 +2201,15 @@
                 ]
             ]
         ],
-        "timestamp": "2026-07-10T15:05:17.243185656",
+        "timestamp": "2026-07-18T18:28:45.433391684",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.04.0"
+            "nextflow": "26.04.3"
         }
     },
     "Params: bwameth with save_reference and save_align_intermeds": {
         "content": [
             {
-                "TRIMGALORE": {
-                    "trimgalore": "0.6.10",
-                    "cutadapt": 4.9,
-                    "pigz": 2.8
-                },
                 "Workflow": {
                     "nf-core/methylseq": "v4.3.0dev"
                 },
@@ -2268,6 +2251,9 @@
                 },
                 "SAMTOOLS_STATS": {
                     "samtools": "1.23.1"
+                },
+                "TRIMGALORE": {
+                    "trimgalore": "2.3.0"
                 }
             },
             [
@@ -2509,7 +2495,7 @@
                 "fastqc_sequence_duplication_levels_plot.txt:md5,9e5712db9aa39b5754ea1e0c49cfff15",
                 "fastqc_top_overrepresented_sequences_table.txt:md5,6dfc5334a09c05392ea17369aa742d01",
                 "multiqc_citations.txt:md5,ad6c1e326b4276501a3b42eaad747de1",
-                "multiqc_cutadapt.txt:md5,883891ac4901385102be053212068732",
+                "multiqc_cutadapt.txt:md5,7ea4af4e9cecb17dd264d60d5975b6ac",
                 "multiqc_picard_dups.txt:md5,82eaab96189f22fd93db38bb516ba6a5",
                 "multiqc_samtools_flagstat.txt:md5,a8f5b45b8b3412a9adc3dd0d35208c73",
                 "multiqc_samtools_stats.txt:md5,edac97e95c57ea6276d3b3801ed732a8",
@@ -2574,20 +2560,15 @@
                 ]
             ]
         ],
-        "timestamp": "2026-07-10T15:08:16.954042711",
+        "timestamp": "2026-07-18T18:31:23.263260168",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.04.0"
+            "nextflow": "26.04.3"
         }
     },
     "Params: bwameth with rrbs": {
         "content": [
             {
-                "TRIMGALORE": {
-                    "trimgalore": "0.6.10",
-                    "cutadapt": 4.9,
-                    "pigz": 2.8
-                },
                 "Workflow": {
                     "nf-core/methylseq": "v4.3.0dev"
                 },
@@ -2623,6 +2604,9 @@
                 },
                 "SAMTOOLS_STATS": {
                     "samtools": "1.23.1"
+                },
+                "TRIMGALORE": {
+                    "trimgalore": "2.3.0"
                 }
             },
             [
@@ -2820,7 +2804,7 @@
                 "fastqc_sequence_duplication_levels_plot.txt:md5,9e5712db9aa39b5754ea1e0c49cfff15",
                 "fastqc_top_overrepresented_sequences_table.txt:md5,6dfc5334a09c05392ea17369aa742d01",
                 "multiqc_citations.txt:md5,ad6c1e326b4276501a3b42eaad747de1",
-                "multiqc_cutadapt.txt:md5,8752cce2e7320f49516e897c60487831",
+                "multiqc_cutadapt.txt:md5,7ea4af4e9cecb17dd264d60d5975b6ac",
                 "multiqc_samtools_flagstat.txt:md5,4389e377eb1db8dde26b0e8db6589c2d",
                 "multiqc_samtools_stats.txt:md5,43600ec0c6685ef4a685fc6085aa7493",
                 "samtools-flagstat-pct-table.txt:md5,6b61188e70378467e23174bd12b1aaaa",
@@ -2847,10 +2831,10 @@
                 ]
             ]
         ],
-        "timestamp": "2026-07-10T15:07:26.553936796",
+        "timestamp": "2026-07-18T18:30:42.897708206",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.04.0"
+            "nextflow": "26.04.3"
         }
     }
 }

--- a/tests/default.nf.test.snap
+++ b/tests/default.nf.test.snap
@@ -2,11 +2,6 @@
     "-profile test": {
         "content": [
             {
-                "TRIMGALORE": {
-                    "trimgalore": "0.6.10",
-                    "cutadapt": 4.9,
-                    "pigz": 2.8
-                },
                 "Workflow": {
                     "nf-core/methylseq": "v4.3.0dev"
                 },
@@ -42,6 +37,9 @@
                 },
                 "SAMTOOLS_SORT": {
                     "samtools": "1.23.1"
+                },
+                "TRIMGALORE": {
+                    "trimgalore": "2.3.0"
                 }
             },
             [
@@ -353,7 +351,7 @@
                 "multiqc_bismark_dedup.txt:md5,d09a5de4d81a3207efb6a8937d060e46",
                 "multiqc_bismark_methextract.txt:md5,4b6db3a59616df1c803713affc07e043",
                 "multiqc_citations.txt:md5,73a6d29705d5a07f17f99c92e3a0f148",
-                "multiqc_cutadapt.txt:md5,883891ac4901385102be053212068732"
+                "multiqc_cutadapt.txt:md5,7ea4af4e9cecb17dd264d60d5975b6ac"
             ],
             [
                 [
@@ -374,10 +372,10 @@
                 ]
             ]
         ],
-        "timestamp": "2026-07-10T15:11:47.138958229",
+        "timestamp": "2026-07-18T18:10:43.769319093",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.04.0"
+            "nextflow": "26.04.3"
         }
     }
 }

--- a/tests/index_downloads.nf.test.snap
+++ b/tests/index_downloads.nf.test.snap
@@ -2,11 +2,6 @@
     "Params: default with bowtie2-index": {
         "content": [
             {
-                "TRIMGALORE": {
-                    "trimgalore": "0.6.10",
-                    "cutadapt": 4.9,
-                    "pigz": 2.8
-                },
                 "Workflow": {
                     "nf-core/methylseq": "v4.3.0dev"
                 },
@@ -40,25 +35,23 @@
                 "SAMTOOLS_SORT": {
                     "samtools": "1.23.1"
                 },
+                "TRIMGALORE": {
+                    "trimgalore": "2.3.0"
+                },
                 "UNTAR_BISMARK": {
                     "untar": 1.34
                 }
             }
         ],
-        "timestamp": "2026-07-10T15:13:13.21908233",
+        "timestamp": "2026-07-18T18:50:42.006015607",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.04.0"
+            "nextflow": "26.04.3"
         }
     },
     "Params: bismark_hisat with hisat2-index": {
         "content": [
             {
-                "TRIMGALORE": {
-                    "trimgalore": "0.6.10",
-                    "cutadapt": 4.9,
-                    "pigz": 2.8
-                },
                 "Workflow": {
                     "nf-core/methylseq": "v4.3.0dev"
                 },
@@ -94,23 +87,21 @@
                 },
                 "SAMTOOLS_SORT": {
                     "samtools": "1.23.1"
+                },
+                "TRIMGALORE": {
+                    "trimgalore": "2.3.0"
                 }
             }
         ],
-        "timestamp": "2026-07-10T15:15:26.659051274",
+        "timestamp": "2026-07-18T18:52:36.791155894",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.04.0"
+            "nextflow": "26.04.3"
         }
     },
     "Params: bismark with run_preseq with bowtie2-index": {
         "content": [
             {
-                "TRIMGALORE": {
-                    "trimgalore": "0.6.10",
-                    "cutadapt": 4.9,
-                    "pigz": 2.8
-                },
                 "Workflow": {
                     "nf-core/methylseq": "v4.3.0dev"
                 },
@@ -144,25 +135,23 @@
                 "SAMTOOLS_SORT": {
                     "samtools": "1.23.1"
                 },
+                "TRIMGALORE": {
+                    "trimgalore": "2.3.0"
+                },
                 "UNTAR_BISMARK": {
                     "untar": 1.34
                 }
             }
         ],
-        "timestamp": "2026-07-10T15:13:55.606693655",
+        "timestamp": "2026-07-18T18:51:20.384462014",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.04.0"
+            "nextflow": "26.04.3"
         }
     },
     "Params: bwameth with bwameth-index": {
         "content": [
             {
-                "TRIMGALORE": {
-                    "trimgalore": "0.6.10",
-                    "cutadapt": 4.9,
-                    "pigz": 2.8
-                },
                 "Workflow": {
                     "nf-core/methylseq": "v4.3.0dev"
                 },
@@ -202,15 +191,18 @@
                 "SAMTOOLS_STATS": {
                     "samtools": "1.23.1"
                 },
+                "TRIMGALORE": {
+                    "trimgalore": "2.3.0"
+                },
                 "UNTAR_BWAMETH": {
                     "untar": 1.34
                 }
             }
         ],
-        "timestamp": "2026-07-10T15:14:45.804488445",
+        "timestamp": "2026-07-18T18:52:00.108596237",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.04.0"
+            "nextflow": "26.04.3"
         }
     }
 }

--- a/tests/targeted_sequencing_variants.nf.test.snap
+++ b/tests/targeted_sequencing_variants.nf.test.snap
@@ -5,11 +5,6 @@
                 "FILTER_BEDGRAPH_TARGETS": {
                     "bedtools": "2.31.1"
                 },
-                "TRIMGALORE": {
-                    "trimgalore": "0.6.10",
-                    "cutadapt": 4.9,
-                    "pigz": 2.8
-                },
                 "Workflow": {
                     "nf-core/methylseq": "v4.3.0dev"
                 },
@@ -51,6 +46,9 @@
                 },
                 "SAMTOOLS_STATS": {
                     "samtools": "1.23.1"
+                },
+                "TRIMGALORE": {
+                    "trimgalore": "2.3.0"
                 }
             },
             [
@@ -274,7 +272,7 @@
                 "fastqc_sequence_duplication_levels_plot.txt:md5,9e5712db9aa39b5754ea1e0c49cfff15",
                 "fastqc_top_overrepresented_sequences_table.txt:md5,6dfc5334a09c05392ea17369aa742d01",
                 "multiqc_citations.txt:md5,ad6c1e326b4276501a3b42eaad747de1",
-                "multiqc_cutadapt.txt:md5,883891ac4901385102be053212068732",
+                "multiqc_cutadapt.txt:md5,7ea4af4e9cecb17dd264d60d5975b6ac",
                 "multiqc_picard_dups.txt:md5,82eaab96189f22fd93db38bb516ba6a5",
                 "multiqc_samtools_flagstat.txt:md5,a8f5b45b8b3412a9adc3dd0d35208c73",
                 "multiqc_samtools_stats.txt:md5,edac97e95c57ea6276d3b3801ed732a8",
@@ -307,10 +305,10 @@
                 ]
             ]
         ],
-        "timestamp": "2026-07-10T14:47:23.538121837",
+        "timestamp": "2026-07-18T18:35:15.620170773",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.04.0"
+            "nextflow": "26.04.3"
         }
     },
     "Params: bismark with run_targeted_sequencing and collecthsmetrics": {
@@ -328,11 +326,6 @@
                 "PICARD_CREATESEQUENCEDICTIONARY": {
                     "picard": "3.4.0"
                 },
-                "TRIMGALORE": {
-                    "trimgalore": "0.6.10",
-                    "cutadapt": 4.9,
-                    "pigz": 2.8
-                },
                 "Workflow": {
                     "nf-core/methylseq": "v4.3.0dev"
                 },
@@ -368,6 +361,9 @@
                 },
                 "SAMTOOLS_SORT": {
                     "samtools": "1.23.1"
+                },
+                "TRIMGALORE": {
+                    "trimgalore": "2.3.0"
                 }
             },
             [
@@ -697,7 +693,7 @@
                 "multiqc_bismark_dedup.txt:md5,d09a5de4d81a3207efb6a8937d060e46",
                 "multiqc_bismark_methextract.txt:md5,4b6db3a59616df1c803713affc07e043",
                 "multiqc_citations.txt:md5,73a6d29705d5a07f17f99c92e3a0f148",
-                "multiqc_cutadapt.txt:md5,883891ac4901385102be053212068732"
+                "multiqc_cutadapt.txt:md5,7ea4af4e9cecb17dd264d60d5975b6ac"
             ],
             [
                 [
@@ -718,10 +714,10 @@
                 ]
             ]
         ],
-        "timestamp": "2026-07-10T14:49:52.844626716",
+        "timestamp": "2026-07-18T18:37:28.963902075",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.04.0"
+            "nextflow": "26.04.3"
         }
     },
     "Params: bismark with run_targeted_sequencing": {
@@ -732,11 +728,6 @@
                 },
                 "FILTER_BEDGRAPH_TARGETS": {
                     "bedtools": "2.31.1"
-                },
-                "TRIMGALORE": {
-                    "trimgalore": "0.6.10",
-                    "cutadapt": 4.9,
-                    "pigz": 2.8
                 },
                 "Workflow": {
                     "nf-core/methylseq": "v4.3.0dev"
@@ -773,6 +764,9 @@
                 },
                 "SAMTOOLS_SORT": {
                     "samtools": "1.23.1"
+                },
+                "TRIMGALORE": {
+                    "trimgalore": "2.3.0"
                 }
             },
             [
@@ -1100,7 +1094,7 @@
                 "multiqc_bismark_dedup.txt:md5,d09a5de4d81a3207efb6a8937d060e46",
                 "multiqc_bismark_methextract.txt:md5,4b6db3a59616df1c803713affc07e043",
                 "multiqc_citations.txt:md5,73a6d29705d5a07f17f99c92e3a0f148",
-                "multiqc_cutadapt.txt:md5,883891ac4901385102be053212068732"
+                "multiqc_cutadapt.txt:md5,7ea4af4e9cecb17dd264d60d5975b6ac"
             ],
             [
                 [
@@ -1121,10 +1115,10 @@
                 ]
             ]
         ],
-        "timestamp": "2026-07-10T14:46:31.06004547",
+        "timestamp": "2026-07-18T18:34:30.113683692",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.04.0"
+            "nextflow": "26.04.3"
         }
     },
     "Params: bwameth with run_targeted_sequencing and collecthsmetrics": {
@@ -1138,11 +1132,6 @@
                 },
                 "PICARD_CREATESEQUENCEDICTIONARY": {
                     "picard": "3.4.0"
-                },
-                "TRIMGALORE": {
-                    "trimgalore": "0.6.10",
-                    "cutadapt": 4.9,
-                    "pigz": 2.8
                 },
                 "Workflow": {
                     "nf-core/methylseq": "v4.3.0dev"
@@ -1185,6 +1174,9 @@
                 },
                 "SAMTOOLS_STATS": {
                     "samtools": "1.23.1"
+                },
+                "TRIMGALORE": {
+                    "trimgalore": "2.3.0"
                 }
             },
             [
@@ -1410,7 +1402,7 @@
                 "fastqc_sequence_duplication_levels_plot.txt:md5,9e5712db9aa39b5754ea1e0c49cfff15",
                 "fastqc_top_overrepresented_sequences_table.txt:md5,6dfc5334a09c05392ea17369aa742d01",
                 "multiqc_citations.txt:md5,ad6c1e326b4276501a3b42eaad747de1",
-                "multiqc_cutadapt.txt:md5,883891ac4901385102be053212068732",
+                "multiqc_cutadapt.txt:md5,7ea4af4e9cecb17dd264d60d5975b6ac",
                 "multiqc_picard_dups.txt:md5,82eaab96189f22fd93db38bb516ba6a5",
                 "multiqc_samtools_flagstat.txt:md5,a8f5b45b8b3412a9adc3dd0d35208c73",
                 "multiqc_samtools_stats.txt:md5,edac97e95c57ea6276d3b3801ed732a8",
@@ -1443,10 +1435,10 @@
                 ]
             ]
         ],
-        "timestamp": "2026-07-10T14:49:09.498606246",
+        "timestamp": "2026-07-18T18:36:48.84177422",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.04.0"
+            "nextflow": "26.04.3"
         }
     },
     "Params: bwameth with all_contexts and run_targeted_sequencing": {
@@ -1454,11 +1446,6 @@
             {
                 "FILTER_BEDGRAPH_TARGETS": {
                     "bedtools": "2.31.1"
-                },
-                "TRIMGALORE": {
-                    "trimgalore": "0.6.10",
-                    "cutadapt": 4.9,
-                    "pigz": 2.8
                 },
                 "Workflow": {
                     "nf-core/methylseq": "v4.3.0dev"
@@ -1501,6 +1488,9 @@
                 },
                 "SAMTOOLS_STATS": {
                     "samtools": "1.23.1"
+                },
+                "TRIMGALORE": {
+                    "trimgalore": "2.3.0"
                 }
             },
             [
@@ -1756,7 +1746,7 @@
                 "fastqc_sequence_duplication_levels_plot.txt:md5,9e5712db9aa39b5754ea1e0c49cfff15",
                 "fastqc_top_overrepresented_sequences_table.txt:md5,6dfc5334a09c05392ea17369aa742d01",
                 "multiqc_citations.txt:md5,ad6c1e326b4276501a3b42eaad747de1",
-                "multiqc_cutadapt.txt:md5,883891ac4901385102be053212068732",
+                "multiqc_cutadapt.txt:md5,7ea4af4e9cecb17dd264d60d5975b6ac",
                 "multiqc_picard_dups.txt:md5,82eaab96189f22fd93db38bb516ba6a5",
                 "multiqc_samtools_flagstat.txt:md5,a8f5b45b8b3412a9adc3dd0d35208c73",
                 "multiqc_samtools_stats.txt:md5,edac97e95c57ea6276d3b3801ed732a8",
@@ -1789,10 +1779,10 @@
                 ]
             ]
         ],
-        "timestamp": "2026-07-10T14:48:15.813960611",
+        "timestamp": "2026-07-18T18:36:04.009565502",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.04.0"
+            "nextflow": "26.04.3"
         }
     }
 }

--- a/workflows/methylseq/main.nf
+++ b/workflows/methylseq/main.nf
@@ -102,7 +102,6 @@ workflow METHYLSEQ {
             ch_fastq
         )
         ch_reads = TRIMGALORE.out.reads
-        ch_versions = ch_versions.mix(TRIMGALORE.out.versions)
     }
     else {
         ch_reads = ch_fastq


### PR DESCRIPTION
## Description

Follow-up to #614: update Trim Galore from `0.6.10` (Perl) to `2.3.0` — the Rust rewrite (faster, single static binary, Cutadapt-free with bundled FastQC).

### Changes

- Bump the `trimgalore` nf-core module `0.6.10` → `2.3.0` via `nf-core modules update` (so `modules.json`'s `git_sha` is updated, not just the files).
- Rewire versions: delete the now-broken `TRIMGALORE.out.versions` mix in `workflows/methylseq/main.nf`. The 2.3.0 module reports its version via the Nextflow topic channel (already collected in the workflow, the same pattern the bismark modules use), so no version is lost.
- CHANGELOG entry.

### Output changes (not byte-identical)

The Rust trimming engine plus the v2.3.0 R2 3' poly-G fix change trimmed reads, so downstream alignment / methylation and MultiQC results shift accordingly; FastQC output also changes (bundled `fastqc-rust`). Verified that the **MultiQC trimming/Cutadapt section is retained** (`multiqc_cutadapt.txt` is still produced under 2.3.0 — no lost QC section, no MultiQC bump needed). `--skip_trimming` runs remain byte-identical.

### Testing

All affected nf-test snapshots were regenerated (`nf-test -profile test,docker`, bismark 3.1.0 container) and pass: `default`, `bismark_variants`, `bismark_hisat_variants`, `bwameth_variants`, `bwamem_taps`, `targeted_sequencing_variants`, `index_downloads`. The **GPU** test (`bwameth_use_gpu`) was regenerated on an NVIDIA L4 (`-profile test,docker,gpu`) and passes. `--skip_trimming` scenarios were confirmed byte-identical (their snapshots are unchanged).
