### PR TITLE
fix: quote env() outputs in RASTAIR_MBIASPARSER for Nextflow strict parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - 🐛 Fix `FILTER_BEDGRAPH_TARGETS` failing on uncompressed (MethylDackel) bedGraph files during targeted sequencing analysis ([#610](https://github.com/nf-core/methylseq/pull/610))
 - 🐛 Remove the `aws_batch` profile, which referenced a deleted config file and broke config parsing (and linting) on recent Nextflow versions ([#610](https://github.com/nf-core/methylseq/pull/610))
+- 🐛 Fix `RASTAIR_MBIASPARSER` strict-parser error by quoting the `env('trim_OT')`/`env('trim_OB')` output declarations (local nf-core module patch); the pipeline now lints cleanly under Nextflow's strict parser (≥25.10)
 
 ## [v4.2.0](https://github.com/nf-core/methylseq/releases/tag/4.2.0) - [2025-12-05]
 

--- a/modules.json
+++ b/modules.json
@@ -158,7 +158,8 @@
                     "rastair/mbiasparser": {
                         "branch": "master",
                         "git_sha": "a4f1768a3026017b92a7e5d1c8b0fb9ac3efa3a9",
-                        "installed_by": ["bam_taps_conversion"]
+                        "installed_by": ["bam_taps_conversion"],
+                        "patch": "modules/nf-core/rastair/mbiasparser/rastair-mbiasparser.diff"
                     },
                     "rastair/methylkit": {
                         "branch": "master",

--- a/modules/nf-core/rastair/mbiasparser/main.nf
+++ b/modules/nf-core/rastair/mbiasparser/main.nf
@@ -12,7 +12,7 @@ process RASTAIR_MBIASPARSER {
     output:
     tuple val(meta), path("*.rastair_mbias_processed.pdf"),         emit: mbias_processed_pdf, optional: true
     tuple val(meta), path("*.rastair_mbias_processed.csv"),         emit: mbias_processed_csv
-    tuple val(meta), env(trim_OT), env(trim_OB),                    emit: mbias_processed_str
+    tuple val(meta), env('trim_OT'), env('trim_OB'),                emit: mbias_processed_str
     path "versions.yml",                                            emit: versions
 
     when:

--- a/modules/nf-core/rastair/mbiasparser/rastair-mbiasparser.diff
+++ b/modules/nf-core/rastair/mbiasparser/rastair-mbiasparser.diff
@@ -1,0 +1,19 @@
+Changes in component 'nf-core/rastair/mbiasparser'
+'modules/nf-core/rastair/mbiasparser/environment.yml' is unchanged
+'modules/nf-core/rastair/mbiasparser/meta.yml' is unchanged
+Changes in 'rastair/mbiasparser/main.nf':
+--- modules/nf-core/rastair/mbiasparser/main.nf
++++ modules/nf-core/rastair/mbiasparser/main.nf
+@@ -12,7 +12,7 @@
+     output:
+     tuple val(meta), path("*.rastair_mbias_processed.pdf"),         emit: mbias_processed_pdf, optional: true
+     tuple val(meta), path("*.rastair_mbias_processed.csv"),         emit: mbias_processed_csv
+-    tuple val(meta), env(trim_OT), env(trim_OB),                    emit: mbias_processed_str
++    tuple val(meta), env('trim_OT'), env('trim_OB'),                emit: mbias_processed_str
+     path "versions.yml",                                            emit: versions
+ 
+     when:
+
+'modules/nf-core/rastair/mbiasparser/tests/main.nf.test.snap' is unchanged
+'modules/nf-core/rastair/mbiasparser/tests/main.nf.test' is unchanged
+************************************************************


### PR DESCRIPTION
## Description

Fixes the Nextflow **strict config/script parser** (≥25.10) error in `RASTAIR_MBIASPARSER`. The bare identifier `env()` output declarations:

```groovy
tuple val(meta), env(trim_OT), env(trim_OB),   emit: mbias_processed_str
```

fail the strict parser with `` `trim_OT` is not defined `` / `` `trim_OB` is not defined ``. The strict parser requires quoted string literals:

```groovy
tuple val(meta), env('trim_OT'), env('trim_OB'),   emit: mbias_processed_str
```

This was the pipeline's **only** strict-parser error, so `nextflow lint` is now clean — a prerequisite for adopting Nextflow ≥25.10.

`rastair` is an nf-core/modules-managed module, so the change is carried as a **local module patch** (`modules/nf-core/rastair/mbiasparser/rastair-mbiasparser.diff`, registered in `modules.json`). The same one-line fix is being upstreamed to nf-core/modules; once released, the patch dissolves on the next `nf-core modules update`.

## Verification

- `nextflow lint` → **0 errors** (whole pipeline strict-clean).
- `nf-core modules lint rastair/mbiasparser` → **0 failures** (patch registered, so `modules_unchanged` passes).

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] `CHANGELOG.md` is updated.
- [x] Code lints (`nextflow lint`, `nf-core modules lint`).

## Upstream status

The equivalent fix already exists on **nf-core/modules `master`**, bundled into a larger modernization of `rastair/mbiasparser` (env vars quoted + renamed to `TRIM_OT`/`TRIM_OB`, container apptainer support, and a migration to **topic-channel versions**). Because adopting that wholesale via `nf-core modules update` would also pull the topic-versions API change (`emit: versions` → `topic: versions`) and require rewiring `bam_taps_conversion`, this PR keeps the minimal local patch for now. The patch will dissolve when the rastair modules are updated to topic-versions in a separate task — so **no upstream PR is needed**.
